### PR TITLE
feat: Nota de Débito electrónica (codDoc 05)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,10 +80,21 @@ EMAIL_PASSWORD=tu_contraseña_o_app_password
 SRI_ENVIRONMENT=1
 
 # URL de recepción del SRI - Ambiente de Pruebas
-SRI_RECEPCION_URL_PRUEBAS=https://celinium.sri.gob.ec/comprobantes-electronicos-ws/RecepcionComprobantesOffline?wsdl
+SRI_RECEPCION_URL_PRUEBAS=https://celcer.sri.gob.ec/comprobantes-electronicos-ws/RecepcionComprobantesOffline?wsdl
 
 # URL de recepción del SRI - Ambiente de Producción
 SRI_RECEPCION_URL_PRODUCCION=https://cel.sri.gob.ec/comprobantes-electronicos-ws/RecepcionComprobantesOffline?wsdl
+
+# URL de autorización del SRI - Ambiente de Pruebas
+SRI_AUTORIZACION_URL_PRUEBAS=https://celcer.sri.gob.ec/comprobantes-electronicos-ws/AutorizacionComprobantesOffline?wsdl
+
+# URL de autorización del SRI - Ambiente de Producción
+SRI_AUTORIZACION_URL_PRODUCCION=https://cel.sri.gob.ec/comprobantes-electronicos-ws/AutorizacionComprobantesOffline?wsdl
+
+# Tarifa de IVA vigente (sin signo de porcentaje) y su código según la tabla 17 del SRI
+# 15% -> codigoPorcentaje 4 (vigente desde abril 2024)
+IVA=15
+CODIGO_PORCENTAJE=4
 
 # =================================
 # ALMACENAMIENTO DE PDFs

--- a/__tests__/creditNote.routes.test.ts
+++ b/__tests__/creditNote.routes.test.ts
@@ -1,0 +1,194 @@
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { createApp } from '../src/testApp';
+
+// --- Model mocks ---
+const creditNoteInstanceMocks = {
+  save: jest.fn().mockResolvedValue({}),
+};
+
+const creditNoteStaticMocks = {
+  find: jest.fn().mockResolvedValue([]),
+  findById: jest.fn().mockResolvedValue(null),
+  findOne: jest.fn().mockResolvedValue(null),
+  findByIdAndUpdate: jest.fn().mockResolvedValue(null),
+  findByIdAndDelete: jest.fn().mockResolvedValue(null),
+};
+
+jest.mock('../src/models/CreditNote', () => {
+  class MockCreditNote {
+    constructor(public data: any) {}
+    save = creditNoteInstanceMocks.save;
+    static find = (...args: any[]) => creditNoteStaticMocks.find(...args);
+    static findById = (...args: any[]) => creditNoteStaticMocks.findById(...args);
+    static findOne = (...args: any[]) => creditNoteStaticMocks.findOne(...args);
+    static findByIdAndUpdate = (...args: any[]) => creditNoteStaticMocks.findByIdAndUpdate(...args);
+    static findByIdAndDelete = (...args: any[]) => creditNoteStaticMocks.findByIdAndDelete(...args);
+  }
+  return { __esModule: true, default: MockCreditNote };
+});
+
+const creditNotePDFStaticMocks = {
+  findOne: jest.fn().mockResolvedValue(null),
+};
+
+jest.mock('../src/models/CreditNotePDF', () => ({
+  __esModule: true,
+  default: {
+    findOne: (...args: any[]) => creditNotePDFStaticMocks.findOne(...args),
+  },
+}));
+
+// --- Service mock ---
+const crearNotaCreditoCompletaMock = jest.fn();
+jest.mock('../src/services/credit-note.service', () => ({
+  CreditNoteService: {
+    crearNotaCreditoCompleta: (...args: any[]) => crearNotaCreditoCompletaMock(...args),
+  },
+}));
+
+const app = createApp();
+const token = jwt.sign({ userId: '1' }, process.env.JWT_SECRET as string);
+const authHeader = `Bearer ${token}`;
+
+const notaCreditoPayload = {
+  infoTributaria: { ruc: '1790012345001' },
+  infoNotaCredito: {
+    fechaEmision: '17/05/2025',
+    tipoIdentificacionComprador: '05',
+    identificacionComprador: '0106079783',
+    codDocModificado: '01',
+    numDocModificado: '001-001-000000123',
+    fechaEmisionDocSustento: '10/05/2025',
+    totalSinImpuestos: '100.00',
+    valorModificacion: '115.00',
+    motivo: 'DEVOLUCIÓN',
+  },
+  detalles: [],
+};
+
+describe('Credit note routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /api/v1/credit-note/complete', () => {
+    it('requires authentication', async () => {
+      const res = await request(app).post('/api/v1/credit-note/complete').send({});
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 400 when nota_credito is missing', async () => {
+      const res = await request(app).post('/api/v1/credit-note/complete').set('Authorization', authHeader).send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(crearNotaCreditoCompletaMock).not.toHaveBeenCalled();
+    });
+
+    it('creates a complete credit note and returns its XML', async () => {
+      const resultadoMock = {
+        nota_credito: { secuencial: '000000001', clave_acceso: '123' },
+        detalles: [],
+        xml: '<notaCredito/>',
+        xml_firmado: null,
+        respuesta_sri: null,
+      };
+      crearNotaCreditoCompletaMock.mockResolvedValueOnce(resultadoMock);
+
+      const res = await request(app)
+        .post('/api/v1/credit-note/complete')
+        .set('Authorization', authHeader)
+        .send({ nota_credito: notaCreditoPayload });
+
+      expect(res.status).toBe(201);
+      expect(res.body.success).toBe(true);
+      expect(res.body.xml).toBe('<notaCredito/>');
+      expect(crearNotaCreditoCompletaMock).toHaveBeenCalledWith(notaCreditoPayload);
+    });
+
+    it('returns 400 for validation errors from the service', async () => {
+      crearNotaCreditoCompletaMock.mockRejectedValueOnce(new Error('Client not found'));
+
+      const res = await request(app)
+        .post('/api/v1/credit-note/complete')
+        .set('Authorization', authHeader)
+        .send({ nota_credito: notaCreditoPayload });
+
+      expect(res.status).toBe(400);
+      expect(res.body.message).toContain('Client not found');
+    });
+
+    it('returns 500 for unexpected service errors', async () => {
+      crearNotaCreditoCompletaMock.mockRejectedValueOnce(new Error('mongo down'));
+
+      const res = await request(app)
+        .post('/api/v1/credit-note/complete')
+        .set('Authorization', authHeader)
+        .send({ nota_credito: notaCreditoPayload });
+
+      expect(res.status).toBe(500);
+      expect(res.body.success).toBe(false);
+    });
+  });
+
+  describe('CRUD endpoints', () => {
+    it('lists credit notes', async () => {
+      creditNoteStaticMocks.find.mockResolvedValueOnce([{ secuencial: '000000001' }]);
+
+      const res = await request(app).get('/api/v1/credit-note').set('Authorization', authHeader);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+    });
+
+    it('returns 404 for a missing credit note', async () => {
+      const res = await request(app)
+        .get('/api/v1/credit-note/507f1f77bcf86cd799439011')
+        .set('Authorization', authHeader);
+
+      expect(res.status).toBe(404);
+    });
+
+    it('returns a credit note by id', async () => {
+      creditNoteStaticMocks.findById.mockResolvedValueOnce({ secuencial: '000000001' });
+
+      const res = await request(app)
+        .get('/api/v1/credit-note/507f1f77bcf86cd799439011')
+        .set('Authorization', authHeader);
+
+      expect(res.status).toBe(200);
+      expect(res.body.secuencial).toBe('000000001');
+    });
+
+    it('returns the PDF info of a credit note', async () => {
+      creditNotePDFStaticMocks.findOne.mockResolvedValueOnce({ pdf_url: 'https://cdn/pdf.pdf', estado: 'GENERADO' });
+
+      const res = await request(app)
+        .get('/api/v1/credit-note/507f1f77bcf86cd799439011/pdf')
+        .set('Authorization', authHeader);
+
+      expect(res.status).toBe(200);
+      expect(res.body.pdf_url).toBe('https://cdn/pdf.pdf');
+    });
+
+    it('returns 404 when the credit note has no PDF yet', async () => {
+      const res = await request(app)
+        .get('/api/v1/credit-note/507f1f77bcf86cd799439011/pdf')
+        .set('Authorization', authHeader);
+
+      expect(res.status).toBe(404);
+    });
+
+    it('deletes a credit note', async () => {
+      creditNoteStaticMocks.findByIdAndDelete.mockResolvedValueOnce({ _id: '507f1f77bcf86cd799439011' });
+
+      const res = await request(app)
+        .delete('/api/v1/credit-note/507f1f77bcf86cd799439011')
+        .set('Authorization', authHeader);
+
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Deleted');
+    });
+  });
+});

--- a/__tests__/debitNote.routes.test.ts
+++ b/__tests__/debitNote.routes.test.ts
@@ -1,0 +1,186 @@
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { createApp } from '../src/testApp';
+
+// --- Model mocks ---
+const debitNoteInstanceMocks = {
+  save: jest.fn().mockResolvedValue({}),
+};
+
+const debitNoteStaticMocks = {
+  find: jest.fn().mockResolvedValue([]),
+  findById: jest.fn().mockResolvedValue(null),
+  findOne: jest.fn().mockResolvedValue(null),
+  findByIdAndUpdate: jest.fn().mockResolvedValue(null),
+  findByIdAndDelete: jest.fn().mockResolvedValue(null),
+};
+
+jest.mock('../src/models/DebitNote', () => {
+  class MockDebitNote {
+    constructor(public data: any) {}
+    save = debitNoteInstanceMocks.save;
+    static find = (...args: any[]) => debitNoteStaticMocks.find(...args);
+    static findById = (...args: any[]) => debitNoteStaticMocks.findById(...args);
+    static findOne = (...args: any[]) => debitNoteStaticMocks.findOne(...args);
+    static findByIdAndUpdate = (...args: any[]) => debitNoteStaticMocks.findByIdAndUpdate(...args);
+    static findByIdAndDelete = (...args: any[]) => debitNoteStaticMocks.findByIdAndDelete(...args);
+  }
+  return { __esModule: true, default: MockDebitNote };
+});
+
+const debitNotePDFStaticMocks = {
+  findOne: jest.fn().mockResolvedValue(null),
+};
+
+jest.mock('../src/models/DebitNotePDF', () => ({
+  __esModule: true,
+  default: {
+    findOne: (...args: any[]) => debitNotePDFStaticMocks.findOne(...args),
+  },
+}));
+
+// --- Service mock ---
+const crearNotaDebitoCompletaMock = jest.fn();
+jest.mock('../src/services/debit-note.service', () => ({
+  DebitNoteService: {
+    crearNotaDebitoCompleta: (...args: any[]) => crearNotaDebitoCompletaMock(...args),
+  },
+}));
+
+const app = createApp();
+const token = jwt.sign({ userId: '1' }, process.env.JWT_SECRET as string);
+const authHeader = `Bearer ${token}`;
+
+const notaDebitoPayload = {
+  infoTributaria: { ruc: '1790012345001' },
+  infoNotaDebito: {
+    fechaEmision: '17/05/2025',
+    tipoIdentificacionComprador: '05',
+    identificacionComprador: '0106079783',
+    codDocModificado: '01',
+    numDocModificado: '001-001-000000123',
+    fechaEmisionDocSustento: '10/05/2025',
+    totalSinImpuestos: '50.00',
+    impuestos: [],
+    valorTotal: '57.50',
+    pagos: [],
+  },
+  motivos: [],
+};
+
+describe('Debit note routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /api/v1/debit-note/complete', () => {
+    it('requires authentication', async () => {
+      const res = await request(app).post('/api/v1/debit-note/complete').send({});
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 400 when nota_debito is missing', async () => {
+      const res = await request(app).post('/api/v1/debit-note/complete').set('Authorization', authHeader).send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(crearNotaDebitoCompletaMock).not.toHaveBeenCalled();
+    });
+
+    it('creates a complete debit note and returns its XML', async () => {
+      const resultadoMock = {
+        nota_debito: { secuencial: '000000001', clave_acceso: '123' },
+        xml: '<notaDebito/>',
+        xml_firmado: null,
+        respuesta_sri: null,
+      };
+      crearNotaDebitoCompletaMock.mockResolvedValueOnce(resultadoMock);
+
+      const res = await request(app)
+        .post('/api/v1/debit-note/complete')
+        .set('Authorization', authHeader)
+        .send({ nota_debito: notaDebitoPayload });
+
+      expect(res.status).toBe(201);
+      expect(res.body.success).toBe(true);
+      expect(res.body.xml).toBe('<notaDebito/>');
+      expect(crearNotaDebitoCompletaMock).toHaveBeenCalledWith(notaDebitoPayload);
+    });
+
+    it('returns 400 for validation errors from the service', async () => {
+      crearNotaDebitoCompletaMock.mockRejectedValueOnce(new Error('Datos de nota de débito inválidos o incompletos'));
+
+      const res = await request(app)
+        .post('/api/v1/debit-note/complete')
+        .set('Authorization', authHeader)
+        .send({ nota_debito: notaDebitoPayload });
+
+      expect(res.status).toBe(400);
+      expect(res.body.message).toContain('inválidos');
+    });
+
+    it('returns 500 for unexpected service errors', async () => {
+      crearNotaDebitoCompletaMock.mockRejectedValueOnce(new Error('mongo down'));
+
+      const res = await request(app)
+        .post('/api/v1/debit-note/complete')
+        .set('Authorization', authHeader)
+        .send({ nota_debito: notaDebitoPayload });
+
+      expect(res.status).toBe(500);
+      expect(res.body.success).toBe(false);
+    });
+  });
+
+  describe('CRUD endpoints', () => {
+    it('lists debit notes', async () => {
+      debitNoteStaticMocks.find.mockResolvedValueOnce([{ secuencial: '000000001' }]);
+
+      const res = await request(app).get('/api/v1/debit-note').set('Authorization', authHeader);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+    });
+
+    it('returns 404 for a missing debit note', async () => {
+      const res = await request(app)
+        .get('/api/v1/debit-note/507f1f77bcf86cd799439011')
+        .set('Authorization', authHeader);
+
+      expect(res.status).toBe(404);
+    });
+
+    it('returns a debit note by id', async () => {
+      debitNoteStaticMocks.findById.mockResolvedValueOnce({ secuencial: '000000001' });
+
+      const res = await request(app)
+        .get('/api/v1/debit-note/507f1f77bcf86cd799439011')
+        .set('Authorization', authHeader);
+
+      expect(res.status).toBe(200);
+      expect(res.body.secuencial).toBe('000000001');
+    });
+
+    it('returns the PDF info of a debit note', async () => {
+      debitNotePDFStaticMocks.findOne.mockResolvedValueOnce({ pdf_url: 'https://cdn/pdf.pdf', estado: 'GENERADO' });
+
+      const res = await request(app)
+        .get('/api/v1/debit-note/507f1f77bcf86cd799439011/pdf')
+        .set('Authorization', authHeader);
+
+      expect(res.status).toBe(200);
+      expect(res.body.pdf_url).toBe('https://cdn/pdf.pdf');
+    });
+
+    it('deletes a debit note', async () => {
+      debitNoteStaticMocks.findByIdAndDelete.mockResolvedValueOnce({ _id: '507f1f77bcf86cd799439011' });
+
+      const res = await request(app)
+        .delete('/api/v1/debit-note/507f1f77bcf86cd799439011')
+        .set('Authorization', authHeader);
+
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Deleted');
+    });
+  });
+});

--- a/__tests__/utils/creditNote.utils.test.ts
+++ b/__tests__/utils/creditNote.utils.test.ts
@@ -1,0 +1,147 @@
+import { generarXMLNotaCredito, obtenerConfiguracionIVA } from '../../src/utils/xml.utils';
+import { generarClaveAcceso, obtenerDigitoVerificador } from '../../src/utils/invoice.utils';
+import { CreditNoteRequest } from '../../src/interfaces/credit-note.interface';
+
+const empresaMock: any = {
+  tipo_ambiente: 1,
+  tipo_emision: 1,
+  razon_social: 'EMPRESA DEMO S.A.',
+  nombre_comercial: 'DEMO',
+  ruc: '1790012345001',
+  codigo_establecimiento: '001',
+  punto_emision: '001',
+  direccion_matriz: 'Av. Principal 123',
+  direccion_establecimiento: 'Av. Principal 123',
+  obligado_contabilidad: true,
+};
+
+const clienteMock: any = {
+  razon_social: 'CLIENTE DE PRUEBA',
+  identificacion: '0106079783',
+  email: 'cliente@test.com',
+  telefono: '0999999999',
+};
+
+const notaCreditoMock: CreditNoteRequest = {
+  infoTributaria: { ruc: '1790012345001', claveAcceso: '', secuencial: '' },
+  infoNotaCredito: {
+    fechaEmision: '17/05/2025',
+    tipoIdentificacionComprador: '05',
+    identificacionComprador: '0106079783',
+    codDocModificado: '01',
+    numDocModificado: '001-001-000000123',
+    fechaEmisionDocSustento: '10/05/2025',
+    totalSinImpuestos: '100.00',
+    valorModificacion: '115.00',
+    motivo: 'DEVOLUCIÓN',
+  },
+  detalles: [
+    {
+      detalle: {
+        codigoInterno: 'P001',
+        descripcion: 'Laptop Lenovo',
+        cantidad: '1.00',
+        precioUnitario: '100.00',
+        precioTotalSinImpuesto: '100.00',
+        impuestos: [
+          {
+            impuesto: {
+              codigo: '2',
+              codigoPorcentaje: '4',
+              tarifa: '15.00',
+              baseImponible: '100.00',
+              valor: '15.00',
+            },
+          },
+        ],
+      },
+    },
+  ],
+};
+
+describe('obtenerConfiguracionIVA', () => {
+  const originalIva = process.env.IVA;
+  const originalCodigo = process.env.CODIGO_PORCENTAJE;
+
+  afterEach(() => {
+    process.env.IVA = originalIva;
+    process.env.CODIGO_PORCENTAJE = originalCodigo;
+    if (originalIva === undefined) delete process.env.IVA;
+    if (originalCodigo === undefined) delete process.env.CODIGO_PORCENTAJE;
+  });
+
+  it('defaults to 15% (codigoPorcentaje 4)', () => {
+    delete process.env.IVA;
+    delete process.env.CODIGO_PORCENTAJE;
+    expect(obtenerConfiguracionIVA()).toEqual({ tarifa: '15', codigoPorcentaje: '4' });
+  });
+
+  it('honors environment overrides', () => {
+    process.env.IVA = '12';
+    process.env.CODIGO_PORCENTAJE = '2';
+    expect(obtenerConfiguracionIVA()).toEqual({ tarifa: '12', codigoPorcentaje: '2' });
+  });
+});
+
+describe('generarClaveAcceso for credit notes', () => {
+  it('generates a 49-digit access key with document type 04', () => {
+    const clave = generarClaveAcceso({
+      fecha: new Date(Date.UTC(2025, 4, 17)),
+      tipoComprobante: '04',
+      ruc: '1790012345001',
+      ambiente: '1',
+      serie: '001001',
+      secuencial: '000000001',
+      codigoNumerico: '12345678',
+      tipoEmision: '1',
+    });
+
+    expect(clave).toHaveLength(49);
+    // ddmmyyyy (8) + tipoComprobante (2)
+    expect(clave.substring(0, 8)).toBe('17052025');
+    expect(clave.substring(8, 10)).toBe('04');
+    // Valid módulo 11 check digit
+    expect(clave[48]).toBe(obtenerDigitoVerificador(clave.substring(0, 48)));
+  });
+});
+
+describe('generarXMLNotaCredito', () => {
+  const xml = generarXMLNotaCredito(
+    notaCreditoMock,
+    empresaMock,
+    clienteMock,
+    '1705202504179001234500110010010000000011234567810',
+    '000000001',
+  );
+
+  it('generates the notaCredito root with version 1.1.0 and id comprobante', () => {
+    expect(xml).toContain('<notaCredito id="comprobante" version="1.1.0">');
+  });
+
+  it('uses codDoc 04', () => {
+    expect(xml).toContain('<codDoc>04</codDoc>');
+  });
+
+  it('includes the infoNotaCredito specific fields', () => {
+    expect(xml).toContain('<codDocModificado>01</codDocModificado>');
+    expect(xml).toContain('<numDocModificado>001-001-000000123</numDocModificado>');
+    expect(xml).toContain('<fechaEmisionDocSustento>10/05/2025</fechaEmisionDocSustento>');
+    expect(xml).toContain('<valorModificacion>115.00</valorModificacion>');
+    expect(xml).toContain('<motivo>DEVOLUCIÓN</motivo>');
+  });
+
+  it('uses codigoInterno for details (not codigoPrincipal)', () => {
+    expect(xml).toContain('<codigoInterno>P001</codigoInterno>');
+    expect(xml).not.toContain('codigoPrincipal');
+  });
+
+  it('takes tax codes from the request details', () => {
+    expect(xml).toContain('<codigoPorcentaje>4</codigoPorcentaje>');
+    expect(xml).toContain('<tarifa>15.00</tarifa>');
+  });
+
+  it('computes totalConImpuestos from the details', () => {
+    expect(xml).toContain('<baseImponible>100.00</baseImponible>');
+    expect(xml).toContain('<valor>15.00</valor>');
+  });
+});

--- a/__tests__/utils/debitNote.utils.test.ts
+++ b/__tests__/utils/debitNote.utils.test.ts
@@ -1,0 +1,142 @@
+import { generarXMLNotaDebito } from '../../src/utils/xml.utils';
+import { generarClaveAcceso, obtenerDigitoVerificador } from '../../src/utils/invoice.utils';
+import { DebitNoteRequest } from '../../src/interfaces/debit-note.interface';
+
+const empresaMock: any = {
+  tipo_ambiente: 1,
+  tipo_emision: 1,
+  razon_social: 'EMPRESA DEMO S.A.',
+  nombre_comercial: 'DEMO',
+  ruc: '1790012345001',
+  codigo_establecimiento: '001',
+  punto_emision: '001',
+  direccion_matriz: 'Av. Principal 123',
+  direccion_establecimiento: 'Av. Principal 123',
+  obligado_contabilidad: true,
+};
+
+const clienteMock: any = {
+  razon_social: 'CLIENTE DE PRUEBA',
+  identificacion: '0106079783',
+  email: 'cliente@test.com',
+  telefono: '0999999999',
+};
+
+const notaDebitoMock: DebitNoteRequest = {
+  infoTributaria: { ruc: '1790012345001', claveAcceso: '', secuencial: '' },
+  infoNotaDebito: {
+    fechaEmision: '17/05/2025',
+    tipoIdentificacionComprador: '05',
+    identificacionComprador: '0106079783',
+    codDocModificado: '01',
+    numDocModificado: '001-001-000000123',
+    fechaEmisionDocSustento: '10/05/2025',
+    totalSinImpuestos: '50.00',
+    impuestos: [
+      {
+        impuesto: {
+          codigo: '2',
+          codigoPorcentaje: '4',
+          tarifa: '15.00',
+          baseImponible: '50.00',
+          valor: '7.50',
+        },
+      },
+    ],
+    valorTotal: '57.50',
+    pagos: [
+      {
+        pago: {
+          formaPago: '20',
+          total: '57.50',
+          plazo: '15',
+          unidadTiempo: 'dias',
+        },
+      },
+    ],
+  },
+  motivos: [
+    {
+      motivo: {
+        razon: 'Interés por mora',
+        valor: '50.00',
+      },
+    },
+  ],
+};
+
+describe('generarClaveAcceso for debit notes', () => {
+  it('generates a 49-digit access key with document type 05', () => {
+    const clave = generarClaveAcceso({
+      fecha: new Date(Date.UTC(2025, 4, 17)),
+      tipoComprobante: '05',
+      ruc: '1790012345001',
+      ambiente: '1',
+      serie: '001001',
+      secuencial: '000000001',
+      codigoNumerico: '12345678',
+      tipoEmision: '1',
+    });
+
+    expect(clave).toHaveLength(49);
+    expect(clave.substring(8, 10)).toBe('05');
+    expect(clave[48]).toBe(obtenerDigitoVerificador(clave.substring(0, 48)));
+  });
+});
+
+describe('generarXMLNotaDebito', () => {
+  const xml = generarXMLNotaDebito(
+    notaDebitoMock,
+    empresaMock,
+    clienteMock,
+    '1705202505179001234500110010010000000011234567810',
+    '000000001',
+  );
+
+  it('generates the notaDebito root with version 1.0.0 and id comprobante', () => {
+    expect(xml).toContain('<notaDebito id="comprobante" version="1.0.0">');
+  });
+
+  it('uses codDoc 05', () => {
+    expect(xml).toContain('<codDoc>05</codDoc>');
+  });
+
+  it('includes the infoNotaDebito specific fields', () => {
+    expect(xml).toContain('<codDocModificado>01</codDocModificado>');
+    expect(xml).toContain('<numDocModificado>001-001-000000123</numDocModificado>');
+    expect(xml).toContain('<fechaEmisionDocSustento>10/05/2025</fechaEmisionDocSustento>');
+    expect(xml).toContain('<totalSinImpuestos>50.00</totalSinImpuestos>');
+    expect(xml).toContain('<valorTotal>57.50</valorTotal>');
+  });
+
+  it('includes the impuestos block with tax codes from the request', () => {
+    expect(xml).toContain('<codigoPorcentaje>4</codigoPorcentaje>');
+    expect(xml).toContain('<tarifa>15.00</tarifa>');
+    expect(xml).toContain('<valor>7.50</valor>');
+  });
+
+  it('includes the pagos block with optional plazo and unidadTiempo', () => {
+    expect(xml).toContain('<formaPago>20</formaPago>');
+    expect(xml).toContain('<total>57.50</total>');
+    expect(xml).toContain('<plazo>15</plazo>');
+    expect(xml).toContain('<unidadTiempo>dias</unidadTiempo>');
+  });
+
+  it('omits plazo and unidadTiempo when not provided', () => {
+    const sinPlazo: DebitNoteRequest = JSON.parse(JSON.stringify(notaDebitoMock));
+    delete sinPlazo.infoNotaDebito.pagos[0].pago.plazo;
+    delete sinPlazo.infoNotaDebito.pagos[0].pago.unidadTiempo;
+
+    const xmlSinPlazo = generarXMLNotaDebito(sinPlazo, empresaMock, clienteMock, 'clave', '000000001');
+
+    expect(xmlSinPlazo).not.toContain('<plazo>');
+    expect(xmlSinPlazo).not.toContain('<unidadTiempo>');
+  });
+
+  it('renders motivos with razon and valor instead of product detalles', () => {
+    expect(xml).toContain('<motivos>');
+    expect(xml).toContain('<razon>Interés por mora</razon>');
+    expect(xml).toContain('<valor>50.00</valor>');
+    expect(xml).not.toContain('<detalles>');
+  });
+});

--- a/__tests__/utils/firma.utils.test.ts
+++ b/__tests__/utils/firma.utils.test.ts
@@ -1,0 +1,101 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import forge from 'node-forge';
+
+const signInvoiceXmlMock = jest.fn().mockReturnValue('<factura>firmada</factura>');
+const signCreditNoteXmlMock = jest.fn().mockReturnValue('<notaCredito>firmada</notaCredito>');
+
+jest.mock('ec-sri-invoice-signer', () => ({
+  signInvoiceXml: (...args: any[]) => signInvoiceXmlMock(...args),
+  signCreditNoteXml: (...args: any[]) => signCreditNoteXmlMock(...args),
+  signDebitNoteXml: jest.fn(),
+  signDeliveryGuideXml: jest.fn(),
+  signWithholdingCertificateXml: jest.fn(),
+}));
+
+import { firmarXML } from '../../src/utils/firma.utils';
+
+const P12_PASSWORD = 'test-password';
+
+/**
+ * Builds a self-signed certificate P12 file for testing
+ */
+function crearP12DePrueba(): string {
+  const keys = forge.pki.rsa.generateKeyPair(2048);
+  const cert = forge.pki.createCertificate();
+  cert.publicKey = keys.publicKey;
+  cert.serialNumber = '01';
+  cert.validity.notBefore = new Date();
+  cert.validity.notAfter = new Date();
+  cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 1);
+
+  const attrs = [
+    { shortName: 'CN', value: 'JUAN PEREZ' },
+    { shortName: 'C', value: 'EC' },
+  ];
+  cert.setSubject(attrs);
+  cert.setIssuer(attrs);
+  cert.sign(keys.privateKey, forge.md.sha256.create());
+
+  const p12Asn1 = forge.pkcs12.toPkcs12Asn1(keys.privateKey, cert, P12_PASSWORD);
+  const p12Der = forge.asn1.toDer(p12Asn1).getBytes();
+
+  const p12Path = path.join(os.tmpdir(), `test-cert-${Date.now()}.p12`);
+  fs.writeFileSync(p12Path, Buffer.from(p12Der, 'binary'));
+  return p12Path;
+}
+
+describe('firmarXML', () => {
+  let p12Path: string;
+
+  beforeAll(() => {
+    p12Path = crearP12DePrueba();
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(p12Path)) fs.unlinkSync(p12Path);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('signs invoices with signInvoiceXml by default', async () => {
+    const resultado = await firmarXML('<factura id="comprobante"/>', p12Path, P12_PASSWORD);
+
+    expect(signInvoiceXmlMock).toHaveBeenCalledTimes(1);
+    expect(signCreditNoteXmlMock).not.toHaveBeenCalled();
+    expect(resultado).toBe('<factura>firmada</factura>');
+  });
+
+  it('signs credit notes with signCreditNoteXml when tipoDocumento is 04', async () => {
+    const resultado = await firmarXML('<notaCredito id="comprobante"/>', p12Path, P12_PASSWORD, '04');
+
+    expect(signCreditNoteXmlMock).toHaveBeenCalledTimes(1);
+    expect(signInvoiceXmlMock).not.toHaveBeenCalled();
+    expect(resultado).toBe('<notaCredito>firmada</notaCredito>');
+  });
+
+  it('passes a rebuilt minimal P12 buffer and the password to the signer', async () => {
+    await firmarXML('<notaCredito id="comprobante"/>', p12Path, P12_PASSWORD, '04');
+
+    const [xml, p12Buffer, options] = signCreditNoteXmlMock.mock.calls[0];
+    expect(xml).toBe('<notaCredito id="comprobante"/>');
+    expect(Buffer.isBuffer(p12Buffer)).toBe(true);
+    expect(p12Buffer.length).toBeGreaterThan(0);
+    expect(options).toEqual({ pkcs12Password: P12_PASSWORD });
+  });
+
+  it('throws a descriptive error when the P12 password is wrong', async () => {
+    await expect(firmarXML('<factura id="comprobante"/>', p12Path, 'wrong-password')).rejects.toThrow(
+      'Error al firmar XML',
+    );
+  });
+
+  it('throws a descriptive error when the P12 file does not exist', async () => {
+    await expect(firmarXML('<factura id="comprobante"/>', '/tmp/no-existe.p12', P12_PASSWORD)).rejects.toThrow(
+      'Error al firmar XML',
+    );
+  });
+});

--- a/__tests__/utils/sri.autorizacion.test.ts
+++ b/__tests__/utils/sri.autorizacion.test.ts
@@ -1,0 +1,119 @@
+import axios from 'axios';
+import { autorizarComprobanteSRI } from '../../src/utils/sri.utils';
+
+jest.mock('axios');
+const axiosMock = axios as jest.Mocked<typeof axios>;
+
+const CLAVE_ACCESO = '1705202504179001234500110010010000000011234567810';
+
+const respuestaAutorizado = `<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <ns2:autorizacionComprobanteResponse xmlns:ns2="http://ec.gob.sri.ws.autorizacion">
+      <RespuestaAutorizacionComprobante>
+        <claveAccesoConsultada>${CLAVE_ACCESO}</claveAccesoConsultada>
+        <numeroComprobantes>1</numeroComprobantes>
+        <autorizaciones>
+          <autorizacion>
+            <estado>AUTORIZADO</estado>
+            <numeroAutorizacion>${CLAVE_ACCESO}</numeroAutorizacion>
+            <fechaAutorizacion>2025-05-17T12:00:00-05:00</fechaAutorizacion>
+            <ambiente>PRUEBAS</ambiente>
+            <comprobante><![CDATA[<notaCredito/>]]></comprobante>
+          </autorizacion>
+        </autorizaciones>
+      </RespuestaAutorizacionComprobante>
+    </ns2:autorizacionComprobanteResponse>
+  </soap:Body>
+</soap:Envelope>`;
+
+const respuestaNoAutorizado = `<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <ns2:autorizacionComprobanteResponse xmlns:ns2="http://ec.gob.sri.ws.autorizacion">
+      <RespuestaAutorizacionComprobante>
+        <autorizaciones>
+          <autorizacion>
+            <estado>NO AUTORIZADO</estado>
+            <fechaAutorizacion>2025-05-17T12:00:00-05:00</fechaAutorizacion>
+            <ambiente>PRUEBAS</ambiente>
+            <mensajes>
+              <mensaje>
+                <identificador>58</identificador>
+                <mensaje>CLAVE ACCESO REGISTRADA</mensaje>
+                <tipo>ERROR</tipo>
+              </mensaje>
+            </mensajes>
+          </autorizacion>
+        </autorizaciones>
+      </RespuestaAutorizacionComprobante>
+    </ns2:autorizacionComprobanteResponse>
+  </soap:Body>
+</soap:Envelope>`;
+
+const respuestaEnProceso = `<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <ns2:autorizacionComprobanteResponse xmlns:ns2="http://ec.gob.sri.ws.autorizacion">
+      <RespuestaAutorizacionComprobante>
+        <claveAccesoConsultada>${CLAVE_ACCESO}</claveAccesoConsultada>
+        <numeroComprobantes>0</numeroComprobantes>
+        <autorizaciones/>
+      </RespuestaAutorizacionComprobante>
+    </ns2:autorizacionComprobanteResponse>
+  </soap:Body>
+</soap:Envelope>`;
+
+describe('autorizarComprobanteSRI', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('parses an AUTORIZADO response', async () => {
+    axiosMock.post.mockResolvedValueOnce({ data: respuestaAutorizado } as any);
+
+    const resultado = await autorizarComprobanteSRI(CLAVE_ACCESO);
+
+    expect(resultado.estado).toBe('AUTORIZADO');
+    expect(resultado.numeroAutorizacion).toBe(CLAVE_ACCESO);
+    expect(resultado.fechaAutorizacion).toBe('2025-05-17T12:00:00-05:00');
+    expect(resultado.ambiente).toBe('PRUEBAS');
+  });
+
+  it('sends the claveAcceso to the authorization SOAP service', async () => {
+    axiosMock.post.mockResolvedValueOnce({ data: respuestaAutorizado } as any);
+
+    await autorizarComprobanteSRI(CLAVE_ACCESO);
+
+    const [url, body] = axiosMock.post.mock.calls[0];
+    expect(url).toContain('AutorizacionComprobantesOffline');
+    expect(body).toContain(`<claveAccesoComprobante>${CLAVE_ACCESO}</claveAccesoComprobante>`);
+    expect(body).toContain('http://ec.gob.sri.ws.autorizacion');
+  });
+
+  it('parses a NO AUTORIZADO response with its mensajes', async () => {
+    axiosMock.post.mockResolvedValueOnce({ data: respuestaNoAutorizado } as any);
+
+    const resultado = await autorizarComprobanteSRI(CLAVE_ACCESO);
+
+    expect(resultado.estado).toBe('NO AUTORIZADO');
+    expect(resultado.mensajes).toBeDefined();
+    expect((resultado.mensajes as any).mensaje.identificador).toBe('58');
+  });
+
+  it('returns EN PROCESO when the SRI has not resolved the receipt yet', async () => {
+    axiosMock.post.mockResolvedValueOnce({ data: respuestaEnProceso } as any);
+
+    const resultado = await autorizarComprobanteSRI(CLAVE_ACCESO);
+
+    expect(resultado.estado).toBe('EN PROCESO');
+  });
+
+  it('returns ERROR_COMUNICACION when the service is unreachable', async () => {
+    axiosMock.post.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const resultado = await autorizarComprobanteSRI(CLAVE_ACCESO);
+
+    expect(resultado.estado).toBe('ERROR_COMUNICACION');
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "cloudinary": "^2.5.1",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
+        "ec-sri-invoice-signer": "^1.8.1",
         "express": "^4.18.2",
         "jsbarcode": "^3.11.6",
         "jsonwebtoken": "^9.0.0",
@@ -1326,6 +1327,18 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@oozcitak/dom": {
       "version": "1.15.10",
       "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-1.15.10.tgz",
@@ -2033,6 +2046,18 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/arg": {
       "version": "4.1.3",
@@ -3048,6 +3073,27 @@
         "xtend": "^4.0.0"
       }
     },
+    "node_modules/ec-sri-invoice-signer": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/ec-sri-invoice-signer/-/ec-sri-invoice-signer-1.8.1.tgz",
+      "integrity": "sha512-oD8Rh6+0ZMH5hoqTofJZp26ZAiwwei5oKU7TlnWgi7qtw6J+vumm0Kab4jRo9P/dGjgGVhbc7pfWjZmNXa8tVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.9.10",
+        "fast-xml-parser": "^5.5.9",
+        "node-forge": "^1.3.3",
+        "xml-crypto": "^6.1.2"
+      }
+    },
+    "node_modules/ec-sri-invoice-signer/node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -3725,6 +3771,45 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+      "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.3.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -4525,6 +4610,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-unsafe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -5906,9 +6003,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
@@ -6284,6 +6381,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-is-absolute": {
@@ -7218,6 +7330,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
+    },
     "node_modules/superagent": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
@@ -7939,6 +8066,21 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlbuilder2": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "cloudinary": "^2.5.1",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
+    "ec-sri-invoice-signer": "^1.8.1",
     "express": "^4.18.2",
     "jsbarcode": "^3.11.6",
     "jsonwebtoken": "^9.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import clientRoutes from './routes/client';
 import productRoutes from './routes/product';
 import invoiceRoutes from './routes/invoice';
 import creditNoteRoutes from './routes/creditNote';
+import debitNoteRoutes from './routes/debitNote';
 import invoiceDetailRoutes from './routes/invoiceDetail';
 import invoicePDFRoutes from './routes/invoicePDF';
 import verifyToken from './middleware/verifyToken';
@@ -94,6 +95,7 @@ app.use('/api/v1/client', clientRoutes);
 app.use('/api/v1/product', productRoutes);
 app.use('/api/v1/invoice', invoiceRoutes);
 app.use('/api/v1/credit-note', creditNoteRoutes);
+app.use('/api/v1/debit-note', debitNoteRoutes);
 app.use('/api/v1/invoice-detail', invoiceDetailRoutes);
 app.use('/api/v1/invoice-pdf', invoicePDFRoutes);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import issuingCompanyRoutes from './routes/issuingCompany';
 import clientRoutes from './routes/client';
 import productRoutes from './routes/product';
 import invoiceRoutes from './routes/invoice';
+import creditNoteRoutes from './routes/creditNote';
 import invoiceDetailRoutes from './routes/invoiceDetail';
 import invoicePDFRoutes from './routes/invoicePDF';
 import verifyToken from './middleware/verifyToken';
@@ -92,6 +93,7 @@ app.use('/api/v1/issuing-company', issuingCompanyRoutes);
 app.use('/api/v1/client', clientRoutes);
 app.use('/api/v1/product', productRoutes);
 app.use('/api/v1/invoice', invoiceRoutes);
+app.use('/api/v1/credit-note', creditNoteRoutes);
 app.use('/api/v1/invoice-detail', invoiceDetailRoutes);
 app.use('/api/v1/invoice-pdf', invoicePDFRoutes);
 

--- a/src/interfaces/credit-note.interface.ts
+++ b/src/interfaces/credit-note.interface.ts
@@ -1,0 +1,70 @@
+import { TaxInfo } from './invoice.interface';
+
+/**
+ * Detalle de una nota de crédito según la Ficha Técnica del SRI (formato XML v1.1.0).
+ * A diferencia de la factura, el detalle usa codigoInterno / codigoAdicional.
+ */
+export interface CreditNoteProductDetail {
+  detalle: {
+    codigoInterno: string;
+    codigoAdicional?: string;
+    descripcion: string;
+    cantidad: string;
+    precioUnitario: string;
+    descuento?: string;
+    precioTotalSinImpuesto: string;
+    impuestos: Array<{
+      impuesto: {
+        codigo: string;
+        codigoPorcentaje: string;
+        tarifa: string;
+        baseImponible: string;
+        valor: string;
+      };
+    }>;
+  };
+}
+
+/**
+ * Información propia de la nota de crédito (nodo infoNotaCredito)
+ */
+export interface CreditNoteInfo {
+  fechaEmision: string;
+  tipoIdentificacionComprador: string;
+  identificacionComprador: string;
+  razonSocialComprador?: string;
+  /** Código del documento que se modifica (tabla 3). Normalmente '01' (factura) */
+  codDocModificado: string;
+  /** Número del documento que se modifica, formato 001-001-000000001 */
+  numDocModificado: string;
+  /** Fecha de emisión del documento de sustento, formato dd/mm/aaaa */
+  fechaEmisionDocSustento: string;
+  totalSinImpuestos: string;
+  /** Valor total de la modificación (incluye impuestos) */
+  valorModificacion: string;
+  moneda?: string;
+  /** Razón de la modificación, ej. DEVOLUCIÓN */
+  motivo: string;
+}
+
+export interface CreditNoteRequest {
+  infoTributaria: TaxInfo;
+  infoNotaCredito: CreditNoteInfo;
+  detalles: CreditNoteProductDetail[];
+}
+
+export interface CreateCreditNoteDTO {
+  empresaId: string | any;
+  clienteId: string | any;
+  facturaModificadaId?: string | any;
+  fechaEmision: Date;
+  claveAcceso: string;
+  secuencial: string;
+  codDocModificado: string;
+  numDocModificado: string;
+  fechaEmisionDocSustento: Date;
+  totalSinImpuestos: number;
+  totalIva: number;
+  valorModificacion: number;
+  motivo: string;
+}

--- a/src/interfaces/debit-note.interface.ts
+++ b/src/interfaces/debit-note.interface.ts
@@ -1,0 +1,63 @@
+import { TaxInfo } from './invoice.interface';
+
+/**
+ * Impuesto de una nota de débito (tabla 16/17 de la Ficha Técnica del SRI)
+ */
+export interface DebitNoteTax {
+  impuesto: {
+    codigo: string;
+    codigoPorcentaje: string;
+    tarifa: string;
+    baseImponible: string;
+    valor: string;
+  };
+}
+
+/**
+ * Pago de una nota de débito (formaPago según tabla 24 de la Ficha Técnica)
+ */
+export interface DebitNotePayment {
+  pago: {
+    formaPago: string;
+    total: string;
+    plazo?: string;
+    unidadTiempo?: string;
+  };
+}
+
+/**
+ * Motivo (recargo) de una nota de débito
+ */
+export interface DebitNoteReason {
+  motivo: {
+    razon: string;
+    valor: string;
+  };
+}
+
+/**
+ * Información propia de la nota de débito (nodo infoNotaDebito)
+ */
+export interface DebitNoteInfo {
+  fechaEmision: string;
+  tipoIdentificacionComprador: string;
+  identificacionComprador: string;
+  razonSocialComprador?: string;
+  /** Código del documento que se modifica (tabla 3). Normalmente '01' (factura) */
+  codDocModificado: string;
+  /** Número del documento que se modifica, formato 001-001-000000001 */
+  numDocModificado: string;
+  /** Fecha de emisión del documento de sustento, formato dd/mm/aaaa */
+  fechaEmisionDocSustento: string;
+  totalSinImpuestos: string;
+  impuestos: DebitNoteTax[];
+  /** Valor total de la nota de débito (base + impuestos) */
+  valorTotal: string;
+  pagos: DebitNotePayment[];
+}
+
+export interface DebitNoteRequest {
+  infoTributaria: TaxInfo;
+  infoNotaDebito: DebitNoteInfo;
+  motivos: DebitNoteReason[];
+}

--- a/src/models/CreditNote.ts
+++ b/src/models/CreditNote.ts
@@ -1,0 +1,55 @@
+import { Schema, model, Document, Types } from 'mongoose';
+
+export interface ICreditNote extends Document {
+  empresa_emisora_id: Types.ObjectId;
+  cliente_id: Types.ObjectId;
+  factura_modificada_id?: Types.ObjectId;
+  fecha_emision: Date;
+  clave_acceso: string;
+  secuencial: string;
+  estado: string;
+  cod_doc_modificado: string;
+  num_doc_modificado: string;
+  fecha_emision_doc_sustento: Date;
+  total_sin_impuestos: number;
+  total_iva: number;
+  valor_modificacion: number;
+  motivo: string;
+  xml: string;
+  xml_firmado: string;
+  autorizacion_numero: string;
+  fecha_autorizacion: Date;
+  sri_estado?: string;
+  sri_mensajes?: any;
+  sri_fecha_envio?: Date;
+  sri_fecha_respuesta?: Date;
+  datos_originales?: string;
+}
+
+const schema = new Schema<ICreditNote>({
+  empresa_emisora_id: { type: Schema.Types.ObjectId, ref: 'IssuingCompany', required: true },
+  cliente_id: { type: Schema.Types.ObjectId, ref: 'Client', required: true },
+  factura_modificada_id: { type: Schema.Types.ObjectId, ref: 'Invoice' },
+  fecha_emision: { type: Date, required: true },
+  clave_acceso: { type: String, required: true },
+  secuencial: { type: String, required: true },
+  estado: { type: String, required: true },
+  cod_doc_modificado: { type: String, required: true },
+  num_doc_modificado: { type: String, required: true },
+  fecha_emision_doc_sustento: { type: Date, required: true },
+  total_sin_impuestos: { type: Number, required: true },
+  total_iva: { type: Number, required: true },
+  valor_modificacion: { type: Number, required: true },
+  motivo: { type: String, required: true },
+  xml: { type: String },
+  xml_firmado: { type: String },
+  autorizacion_numero: { type: String },
+  fecha_autorizacion: { type: Date },
+  sri_estado: { type: String },
+  sri_mensajes: { type: Schema.Types.Mixed },
+  sri_fecha_envio: { type: Date },
+  sri_fecha_respuesta: { type: Date },
+  datos_originales: { type: String },
+});
+
+export default model<ICreditNote>('CreditNote', schema);

--- a/src/models/CreditNoteDetail.ts
+++ b/src/models/CreditNoteDetail.ts
@@ -1,0 +1,21 @@
+import { Schema, model, Document, Types } from 'mongoose';
+
+export interface ICreditNoteDetail extends Document {
+  nota_credito_id: Types.ObjectId;
+  producto_id: Types.ObjectId;
+  cantidad: number;
+  precio_unitario: number;
+  subtotal: number;
+  valor_iva: number;
+}
+
+const schema = new Schema<ICreditNoteDetail>({
+  nota_credito_id: { type: Schema.Types.ObjectId, ref: 'CreditNote', required: true },
+  producto_id: { type: Schema.Types.ObjectId, ref: 'Product', required: true },
+  cantidad: { type: Number, required: true },
+  precio_unitario: { type: Number, required: true },
+  subtotal: { type: Number, required: true },
+  valor_iva: { type: Number, required: true },
+});
+
+export default model<ICreditNoteDetail>('CreditNoteDetail', schema);

--- a/src/models/CreditNotePDF.ts
+++ b/src/models/CreditNotePDF.ts
@@ -1,0 +1,40 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+/**
+ * PDF (RIDE) de una nota de crédito.
+ * Igual que InvoicePDF, no almacena el buffer: solo la URL pública del proveedor.
+ */
+export interface ICreditNotePDF extends Document {
+  nota_credito_id: string;
+  claveAcceso: string;
+
+  pdf_url: string;
+  pdf_public_id: string;
+  pdf_provider: string;
+
+  fecha_generacion: Date;
+  estado: 'GENERADO' | 'ERROR';
+  tamano_archivo: number;
+  numero_autorizacion: string;
+  fecha_autorizacion: Date;
+}
+
+const CreditNotePDFSchema: Schema = new Schema({
+  nota_credito_id: { type: String, required: true, ref: 'CreditNote' },
+  claveAcceso: { type: String, required: true, unique: true },
+
+  pdf_url: { type: String },
+  pdf_public_id: { type: String },
+  pdf_provider: { type: String, default: 'local' },
+
+  fecha_generacion: { type: Date, default: Date.now },
+  estado: { type: String, enum: ['GENERADO', 'ERROR'], default: 'GENERADO' },
+  tamano_archivo: { type: Number, required: true, default: 0 },
+  numero_autorizacion: { type: String, required: true },
+  fecha_autorizacion: { type: Date, required: true },
+});
+
+CreditNotePDFSchema.index({ nota_credito_id: 1 });
+CreditNotePDFSchema.index({ pdf_public_id: 1 });
+
+export default mongoose.model<ICreditNotePDF>('CreditNotePDF', CreditNotePDFSchema);

--- a/src/models/DebitNote.ts
+++ b/src/models/DebitNote.ts
@@ -1,0 +1,60 @@
+import { Schema, model, Document, Types } from 'mongoose';
+
+export interface IDebitNote extends Document {
+  empresa_emisora_id: Types.ObjectId;
+  cliente_id: Types.ObjectId;
+  factura_modificada_id?: Types.ObjectId;
+  fecha_emision: Date;
+  clave_acceso: string;
+  secuencial: string;
+  estado: string;
+  cod_doc_modificado: string;
+  num_doc_modificado: string;
+  fecha_emision_doc_sustento: Date;
+  total_sin_impuestos: number;
+  total_impuestos: number;
+  valor_total: number;
+  motivos: Array<{ razon: string; valor: number }>;
+  xml: string;
+  xml_firmado: string;
+  autorizacion_numero: string;
+  fecha_autorizacion: Date;
+  sri_estado?: string;
+  sri_mensajes?: any;
+  sri_fecha_envio?: Date;
+  sri_fecha_respuesta?: Date;
+  datos_originales?: string;
+}
+
+const schema = new Schema<IDebitNote>({
+  empresa_emisora_id: { type: Schema.Types.ObjectId, ref: 'IssuingCompany', required: true },
+  cliente_id: { type: Schema.Types.ObjectId, ref: 'Client', required: true },
+  factura_modificada_id: { type: Schema.Types.ObjectId, ref: 'Invoice' },
+  fecha_emision: { type: Date, required: true },
+  clave_acceso: { type: String, required: true },
+  secuencial: { type: String, required: true },
+  estado: { type: String, required: true },
+  cod_doc_modificado: { type: String, required: true },
+  num_doc_modificado: { type: String, required: true },
+  fecha_emision_doc_sustento: { type: Date, required: true },
+  total_sin_impuestos: { type: Number, required: true },
+  total_impuestos: { type: Number, required: true },
+  valor_total: { type: Number, required: true },
+  motivos: [
+    {
+      razon: { type: String, required: true },
+      valor: { type: Number, required: true },
+    },
+  ],
+  xml: { type: String },
+  xml_firmado: { type: String },
+  autorizacion_numero: { type: String },
+  fecha_autorizacion: { type: Date },
+  sri_estado: { type: String },
+  sri_mensajes: { type: Schema.Types.Mixed },
+  sri_fecha_envio: { type: Date },
+  sri_fecha_respuesta: { type: Date },
+  datos_originales: { type: String },
+});
+
+export default model<IDebitNote>('DebitNote', schema);

--- a/src/models/DebitNotePDF.ts
+++ b/src/models/DebitNotePDF.ts
@@ -1,0 +1,40 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+/**
+ * PDF (RIDE) de una nota de débito.
+ * Igual que InvoicePDF, no almacena el buffer: solo la URL pública del proveedor.
+ */
+export interface IDebitNotePDF extends Document {
+  nota_debito_id: string;
+  claveAcceso: string;
+
+  pdf_url: string;
+  pdf_public_id: string;
+  pdf_provider: string;
+
+  fecha_generacion: Date;
+  estado: 'GENERADO' | 'ERROR';
+  tamano_archivo: number;
+  numero_autorizacion: string;
+  fecha_autorizacion: Date;
+}
+
+const DebitNotePDFSchema: Schema = new Schema({
+  nota_debito_id: { type: String, required: true, ref: 'DebitNote' },
+  claveAcceso: { type: String, required: true, unique: true },
+
+  pdf_url: { type: String },
+  pdf_public_id: { type: String },
+  pdf_provider: { type: String, default: 'local' },
+
+  fecha_generacion: { type: Date, default: Date.now },
+  estado: { type: String, enum: ['GENERADO', 'ERROR'], default: 'GENERADO' },
+  tamano_archivo: { type: Number, required: true, default: 0 },
+  numero_autorizacion: { type: String, required: true },
+  fecha_autorizacion: { type: Date, required: true },
+});
+
+DebitNotePDFSchema.index({ nota_debito_id: 1 });
+DebitNotePDFSchema.index({ pdf_public_id: 1 });
+
+export default mongoose.model<IDebitNotePDF>('DebitNotePDF', DebitNotePDFSchema);

--- a/src/routes/creditNote.ts
+++ b/src/routes/creditNote.ts
@@ -1,0 +1,111 @@
+import { Router } from 'express';
+import CreditNote from '../models/CreditNote';
+import CreditNotePDF from '../models/CreditNotePDF';
+import { CreditNoteService } from '../services/credit-note.service';
+
+const router = Router();
+
+router.post('/', async (req, res) => {
+  try {
+    const doc = new CreditNote(req.body);
+    await doc.save();
+    res.status(201).json(doc);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.post('/complete', async (req, res) => {
+  try {
+    if (!req.body.nota_credito) {
+      return res.status(400).json({
+        success: false,
+        message: 'Credit note data is required',
+      });
+    }
+
+    const resultado = await CreditNoteService.crearNotaCreditoCompleta(req.body.nota_credito);
+
+    return res.status(201).json({
+      success: true,
+      data: resultado,
+      xml: resultado.xml,
+    });
+  } catch (err: any) {
+    // Errors that should return 400 (Bad Request)
+    const validationErrors = [
+      'Product not found',
+      'Client not found',
+      'Identification type not found',
+      'Empresa emisora no encontrada',
+      'Invalid date format',
+      'Datos de nota de crédito inválidos o incompletos',
+    ];
+
+    const isValidationError = validationErrors.some((error) => err.message.includes(error));
+
+    if (isValidationError) {
+      return res.status(400).json({
+        success: false,
+        message: err.message,
+      });
+    }
+
+    // All other errors are server errors (500)
+    return res.status(500).json({
+      success: false,
+      message: err.message,
+    });
+  }
+});
+
+router.get('/', async (_req, res) => {
+  try {
+    const docs = await CreditNote.find();
+    res.json(docs);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.get('/:id', async (req, res) => {
+  try {
+    const doc = await CreditNote.findById(req.params.id);
+    if (!doc) return res.status(404).json({ message: 'Not found' });
+    res.json(doc);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.get('/:id/pdf', async (req, res) => {
+  try {
+    const doc = await CreditNotePDF.findOne({ nota_credito_id: req.params.id });
+    if (!doc) return res.status(404).json({ message: 'Not found' });
+    res.json(doc);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.put('/:id', async (req, res) => {
+  try {
+    const doc = await CreditNote.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!doc) return res.status(404).json({ message: 'Not found' });
+    res.json(doc);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.delete('/:id', async (req, res) => {
+  try {
+    const doc = await CreditNote.findByIdAndDelete(req.params.id);
+    if (!doc) return res.status(404).json({ message: 'Not found' });
+    res.json({ message: 'Deleted' });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+export default router;

--- a/src/routes/debitNote.ts
+++ b/src/routes/debitNote.ts
@@ -1,0 +1,110 @@
+import { Router } from 'express';
+import DebitNote from '../models/DebitNote';
+import DebitNotePDF from '../models/DebitNotePDF';
+import { DebitNoteService } from '../services/debit-note.service';
+
+const router = Router();
+
+router.post('/', async (req, res) => {
+  try {
+    const doc = new DebitNote(req.body);
+    await doc.save();
+    res.status(201).json(doc);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.post('/complete', async (req, res) => {
+  try {
+    if (!req.body.nota_debito) {
+      return res.status(400).json({
+        success: false,
+        message: 'Debit note data is required',
+      });
+    }
+
+    const resultado = await DebitNoteService.crearNotaDebitoCompleta(req.body.nota_debito);
+
+    return res.status(201).json({
+      success: true,
+      data: resultado,
+      xml: resultado.xml,
+    });
+  } catch (err: any) {
+    // Errors that should return 400 (Bad Request)
+    const validationErrors = [
+      'Client not found',
+      'Identification type not found',
+      'Empresa emisora no encontrada',
+      'Invalid date format',
+      'Datos de nota de débito inválidos o incompletos',
+    ];
+
+    const isValidationError = validationErrors.some((error) => err.message.includes(error));
+
+    if (isValidationError) {
+      return res.status(400).json({
+        success: false,
+        message: err.message,
+      });
+    }
+
+    // All other errors are server errors (500)
+    return res.status(500).json({
+      success: false,
+      message: err.message,
+    });
+  }
+});
+
+router.get('/', async (_req, res) => {
+  try {
+    const docs = await DebitNote.find();
+    res.json(docs);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.get('/:id', async (req, res) => {
+  try {
+    const doc = await DebitNote.findById(req.params.id);
+    if (!doc) return res.status(404).json({ message: 'Not found' });
+    res.json(doc);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.get('/:id/pdf', async (req, res) => {
+  try {
+    const doc = await DebitNotePDF.findOne({ nota_debito_id: req.params.id });
+    if (!doc) return res.status(404).json({ message: 'Not found' });
+    res.json(doc);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.put('/:id', async (req, res) => {
+  try {
+    const doc = await DebitNote.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!doc) return res.status(404).json({ message: 'Not found' });
+    res.json(doc);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.delete('/:id', async (req, res) => {
+  try {
+    const doc = await DebitNote.findByIdAndDelete(req.params.id);
+    if (!doc) return res.status(404).json({ message: 'Not found' });
+    res.json({ message: 'Deleted' });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+export default router;

--- a/src/services/credit-note.service.ts
+++ b/src/services/credit-note.service.ts
@@ -1,0 +1,417 @@
+import { CreditNoteRequest, CreditNoteProductDetail } from '../interfaces/credit-note.interface';
+import { convertirFecha, generarClaveAcceso } from '../utils/invoice.utils';
+import { generarXMLNotaCredito } from '../utils/xml.utils';
+import { firmarXML } from '../utils/firma.utils';
+import { enviarComprobanteSRI, autorizarComprobanteSRI, AutorizacionSRI, RespuestaSRI } from '../utils/sri.utils';
+import { generateCreditNotePDF } from '../utils/pdf.utils';
+import { PDFStorageFactory } from './storage';
+import { InvoiceService } from './invoice.service';
+import CreditNote from '../models/CreditNote';
+import CreditNoteDetail from '../models/CreditNoteDetail';
+import CreditNotePDF from '../models/CreditNotePDF';
+import Invoice from '../models/Invoice';
+import IssuingCompany from '../models/IssuingCompany';
+import { IClient } from '../models/Client';
+import { IProduct } from '../models/Product';
+import fs from 'fs';
+
+/**
+ * Servicio para manejar todas las operaciones relacionadas con notas de crédito (codDoc 04)
+ */
+export class CreditNoteService {
+  /**
+   * Valida que los datos básicos de una nota de crédito estén presentes
+   */
+  static validarDatosNotaCredito(datos: CreditNoteRequest): boolean {
+    return !!(
+      datos.infoTributaria &&
+      datos.infoNotaCredito &&
+      datos.detalles &&
+      datos.detalles.length > 0 &&
+      datos.infoNotaCredito.numDocModificado &&
+      datos.infoNotaCredito.motivo
+    );
+  }
+
+  /**
+   * Genera el siguiente secuencial de nota de crédito para una empresa
+   */
+  static async generarSecuencial(rucCompany: string): Promise<string> {
+    const empresa = await IssuingCompany.findOne({ ruc: rucCompany });
+    if (!empresa) {
+      throw new Error(`Empresa with RUC ${rucCompany} not found`);
+    }
+
+    const ultimaNota = await CreditNote.findOne({
+      empresa_emisora_id: empresa._id,
+    }).sort({ secuencial: -1 });
+
+    let secuencial = '000000001';
+    if (ultimaNota) {
+      const siguiente = parseInt(ultimaNota.secuencial) + 1;
+      secuencial = siguiente.toString().padStart(9, '0');
+    }
+    return secuencial;
+  }
+
+  /**
+   * Busca todos los productos listados en los detalles de una nota de crédito
+   */
+  static async buscarProducts(detalles: CreditNoteProductDetail[]): Promise<IProduct[]> {
+    const productos = [];
+    for (const det of detalles) {
+      const codigo = det.detalle?.codigoInterno;
+      const producto = await InvoiceService.buscarProduct(codigo);
+      if (!producto) {
+        throw new Error(`Product not found: ${codigo}`);
+      }
+      productos.push(producto);
+    }
+    return productos;
+  }
+
+  /**
+   * Valida y resuelve todas las entidades necesarias para emitir la nota de crédito
+   */
+  static async procesarNotaCreditoCompleta(datos: CreditNoteRequest) {
+    if (!this.validarDatosNotaCredito(datos)) {
+      throw new Error('Datos de nota de crédito inválidos o incompletos');
+    }
+
+    const tipoIdent = await InvoiceService.buscarTipoIdentificacion(datos.infoNotaCredito.tipoIdentificacionComprador);
+    if (!tipoIdent) {
+      throw new Error('Identification type not found');
+    }
+
+    const empresa = await InvoiceService.buscarIssuingCompany(datos.infoTributaria.ruc);
+    if (!empresa) {
+      throw new Error('Empresa emisora no encontrada');
+    }
+
+    const cliente = await InvoiceService.buscarClient(datos.infoNotaCredito.identificacionComprador);
+    if (!cliente) {
+      throw new Error('Client not found');
+    }
+
+    const productos = await this.buscarProducts(datos.detalles);
+    const secuencial = await this.generarSecuencial(empresa.ruc);
+    const fechaEmision = convertirFecha(datos.infoNotaCredito.fechaEmision);
+    const fechaEmisionDocSustento = convertirFecha(datos.infoNotaCredito.fechaEmisionDocSustento);
+
+    if (isNaN(fechaEmision.getTime()) || isNaN(fechaEmisionDocSustento.getTime())) {
+      throw new Error('Invalid date format');
+    }
+
+    // Optional link to the modified invoice when it exists in this system
+    const facturaModificada = await Invoice.findOne({
+      empresa_emisora_id: empresa._id,
+      secuencial: datos.infoNotaCredito.numDocModificado.split('-').pop(),
+    });
+
+    return {
+      empresa,
+      cliente,
+      productos,
+      secuencial,
+      fechaEmision,
+      fechaEmisionDocSustento,
+      facturaModificada,
+    };
+  }
+
+  /**
+   * Procesa y guarda una nota de crédito completa con todos sus detalles,
+   * y dispara el envío asíncrono al SRI
+   * @param datos Los datos de la nota de crédito recibidos del cliente
+   * @returns La nota de crédito creada y sus detalles
+   */
+  static async crearNotaCreditoCompleta(datos: CreditNoteRequest) {
+    const { empresa, cliente, productos, secuencial, fechaEmision, fechaEmisionDocSustento, facturaModificada } =
+      await this.procesarNotaCreditoCompleta(datos);
+
+    const serie = `${empresa.codigo_establecimiento}${empresa.punto_emision}`;
+    const claveAcceso = generarClaveAcceso({
+      fecha: fechaEmision,
+      tipoComprobante: '04',
+      ruc: empresa.ruc,
+      ambiente: empresa.tipo_ambiente.toString(),
+      serie,
+      secuencial,
+      codigoNumerico: Math.floor(10000000 + Math.random() * 89999999).toString(),
+      tipoEmision: empresa.tipo_emision.toString(),
+    });
+
+    const totalSinImpuestos = parseFloat(datos.infoNotaCredito.totalSinImpuestos);
+    const totalIva = datos.detalles.reduce((s, d) => s + parseFloat(d.detalle.impuestos[0].impuesto.valor), 0);
+    const valorModificacion = parseFloat(datos.infoNotaCredito.valorModificacion);
+
+    const xml = generarXMLNotaCredito(datos, empresa, cliente, claveAcceso, secuencial);
+
+    const notaCredito = new CreditNote({
+      empresa_emisora_id: empresa._id,
+      cliente_id: cliente._id,
+      factura_modificada_id: facturaModificada?._id,
+      fecha_emision: fechaEmision,
+      clave_acceso: claveAcceso,
+      secuencial,
+      estado: 'CREADA',
+      cod_doc_modificado: datos.infoNotaCredito.codDocModificado,
+      num_doc_modificado: datos.infoNotaCredito.numDocModificado,
+      fecha_emision_doc_sustento: fechaEmisionDocSustento,
+      total_sin_impuestos: totalSinImpuestos,
+      total_iva: totalIva,
+      valor_modificacion: valorModificacion,
+      motivo: datos.infoNotaCredito.motivo,
+      xml,
+      sri_estado: 'PENDIENTE',
+      datos_originales: JSON.stringify(datos),
+    });
+
+    await notaCredito.save();
+
+    this.procesarEnvioSRI(notaCredito, empresa, cliente, productos, datos).catch((error) => {
+      console.error('Error in asynchronous SRI sending process:', error);
+    });
+
+    const detallesGuardados = await this.crearDetallesNotaCredito(notaCredito._id, datos.detalles, productos);
+
+    return {
+      nota_credito: notaCredito,
+      detalles: detallesGuardados,
+      xml: notaCredito.xml,
+      xml_firmado: notaCredito.xml_firmado || null,
+      respuesta_sri: null,
+    };
+  }
+
+  /**
+   * Crea los detalles de una nota de crédito en la base de datos
+   */
+  static async crearDetallesNotaCredito(
+    notaCreditoId: string | any,
+    detalles: CreditNoteProductDetail[],
+    products: IProduct[],
+  ) {
+    const detallesGuardados = [];
+
+    for (let i = 0; i < detalles.length; i++) {
+      const det = detalles[i].detalle;
+      const prod = products[i];
+
+      const detDoc = new CreditNoteDetail({
+        nota_credito_id: notaCreditoId,
+        producto_id: prod._id,
+        cantidad: parseFloat(det.cantidad),
+        precio_unitario: parseFloat(det.precioUnitario),
+        subtotal: parseFloat(det.precioTotalSinImpuesto),
+        valor_iva: parseFloat(det.impuestos[0].impuesto.valor),
+      });
+
+      await detDoc.save();
+      detallesGuardados.push(detDoc);
+    }
+
+    return detallesGuardados;
+  }
+
+  /**
+   * Procesa el envío asíncrono de la nota de crédito al SRI:
+   * firma XAdES-BES, recepción y consulta de autorización
+   */
+  static async procesarEnvioSRI(
+    notaCredito: any,
+    empresa: any,
+    cliente: IClient,
+    productos: IProduct[],
+    datos: CreditNoteRequest,
+  ): Promise<void> {
+    let respuestaSRI: RespuestaSRI | null = null;
+
+    try {
+      const p12Path = empresa.certificatePath;
+      const p12Password = empresa.certificatePassword || '';
+
+      if (!p12Path || !fs.existsSync(p12Path)) {
+        notaCredito.sri_estado = 'ERROR_FIRMA';
+        notaCredito.sri_mensajes = { mensaje: 'Certificate not found for signing' };
+        await notaCredito.save();
+        return;
+      }
+
+      try {
+        const diagnosis = await InvoiceService.diagnoseP12Certificate(p12Path, p12Password);
+        if (!diagnosis.isValidP12) {
+          throw new Error(`El archivo P12 no es válido: ${diagnosis.error}`);
+        }
+
+        let workingPassword = p12Password;
+        const passwordVerification = await InvoiceService.verifyP12Password(p12Path, p12Password);
+        if (!passwordVerification.valid) {
+          const passwordSearch = await InvoiceService.findWorkingP12Password(p12Path, p12Password);
+          if (passwordSearch.password === null) {
+            throw new Error(`Error de contraseña del certificado P12: ${passwordVerification.error}`);
+          }
+          workingPassword = passwordSearch.password;
+        }
+
+        const xmlFirmado = await firmarXML(notaCredito.xml, p12Path, workingPassword, '04');
+
+        notaCredito.xml_firmado = xmlFirmado;
+        notaCredito.sri_fecha_envio = new Date();
+        await notaCredito.save();
+
+        respuestaSRI = await enviarComprobanteSRI(xmlFirmado);
+
+        notaCredito.sri_fecha_respuesta = new Date();
+        notaCredito.sri_estado = respuestaSRI.estado;
+        if (respuestaSRI.mensajes) {
+          notaCredito.sri_mensajes = respuestaSRI.mensajes;
+        }
+        await notaCredito.save();
+
+        if (respuestaSRI.estado === 'RECIBIDA') {
+          console.log(
+            `✅ NOTA DE CRÉDITO RECIBIDA POR SRI - ID: ${notaCredito._id}, Clave: ${notaCredito.clave_acceso}, Secuencial: ${notaCredito.secuencial}`,
+          );
+          await this.generarPDFNotaCredito(notaCredito, empresa, cliente, productos, datos);
+          this.programarConsultaAutorizacion(String(notaCredito._id));
+        } else {
+          console.log(`⚠️ SRI Estado: ${respuestaSRI.estado} - Nota de crédito ID: ${notaCredito._id}`);
+        }
+      } catch (error: any) {
+        console.error('Error during certificate processing or signing:', error.message);
+        notaCredito.sri_estado = 'ERROR_FIRMA';
+        notaCredito.sri_mensajes = { error: error.message };
+        await notaCredito.save();
+      }
+    } catch (error: any) {
+      console.error('Error during signing or sending to SRI:', error.message);
+      notaCredito.sri_estado = 'ERROR_PROCESO';
+      notaCredito.sri_mensajes = { error: error.message };
+      await notaCredito.save();
+    }
+  }
+
+  /**
+   * Programa consultas de autorización al SRI con reintentos
+   */
+  static programarConsultaAutorizacion(notaCreditoId: string, intento = 1, maxIntentos = 3, delayMs = 5000): void {
+    const timer = setTimeout(async () => {
+      try {
+        const resultado = await CreditNoteService.consultarAutorizacionSRI(notaCreditoId);
+        const pendiente = !resultado || (resultado.estado !== 'AUTORIZADO' && resultado.estado !== 'NO AUTORIZADO');
+
+        if (pendiente && intento < maxIntentos) {
+          CreditNoteService.programarConsultaAutorizacion(notaCreditoId, intento + 1, maxIntentos, delayMs);
+        }
+      } catch (error: any) {
+        console.error('Error en la consulta de autorización automática:', error.message);
+      }
+    }, delayMs);
+
+    timer.unref?.();
+  }
+
+  /**
+   * Consulta el estado de autorización de una nota de crédito ya recibida por el SRI
+   * y actualiza el documento con el resultado
+   */
+  static async consultarAutorizacionSRI(notaCreditoId: string): Promise<AutorizacionSRI | null> {
+    try {
+      const notaCredito = await CreditNote.findById(notaCreditoId);
+      if (!notaCredito || !notaCredito.clave_acceso) {
+        throw new Error('Nota de crédito no encontrada o sin clave de acceso');
+      }
+
+      const respuesta = await autorizarComprobanteSRI(notaCredito.clave_acceso);
+
+      notaCredito.sri_estado = respuesta.estado;
+      notaCredito.sri_fecha_respuesta = new Date();
+      if (respuesta.mensajes) {
+        notaCredito.sri_mensajes = respuesta.mensajes;
+      }
+
+      if (respuesta.estado === 'AUTORIZADO') {
+        notaCredito.estado = 'AUTORIZADA';
+        notaCredito.autorizacion_numero = respuesta.numeroAutorizacion || notaCredito.clave_acceso;
+        notaCredito.fecha_autorizacion = respuesta.fechaAutorizacion
+          ? new Date(respuesta.fechaAutorizacion)
+          : new Date();
+        console.log(`✅ NOTA DE CRÉDITO AUTORIZADA POR SRI - Secuencial: ${notaCredito.secuencial}`);
+      }
+
+      await notaCredito.save();
+      return respuesta;
+    } catch (error: any) {
+      console.error('Error al consultar autorización SRI:', error.message);
+      return null;
+    }
+  }
+
+  /**
+   * Genera y almacena el PDF (RIDE) de una nota de crédito recibida por el SRI
+   */
+  static async generarPDFNotaCredito(
+    notaCredito: any,
+    empresa: any,
+    cliente: IClient,
+    productos: IProduct[],
+    datos: CreditNoteRequest,
+  ): Promise<void> {
+    try {
+      const numeroAutorizacion = notaCredito.clave_acceso;
+      const fechaAutorizacion = notaCredito.sri_fecha_respuesta || new Date();
+
+      const pdfBuffer = await generateCreditNotePDF({
+        notaCredito: datos,
+        empresa,
+        cliente,
+        productos,
+        claveAcceso: notaCredito.clave_acceso,
+        secuencial: notaCredito.secuencial,
+        fechaEmision: notaCredito.fecha_emision,
+        numeroAutorizacion,
+        fechaAutorizacion,
+      });
+
+      const storage = PDFStorageFactory.create();
+      const filename = `nota_credito_${notaCredito.secuencial}_${notaCredito.clave_acceso}`;
+      const uploadResult = await storage.upload(pdfBuffer, filename);
+
+      const creditNotePDF = new CreditNotePDF({
+        nota_credito_id: notaCredito._id,
+        claveAcceso: notaCredito.clave_acceso,
+        pdf_url: uploadResult.url,
+        pdf_public_id: uploadResult.publicId,
+        pdf_provider: uploadResult.provider,
+        tamano_archivo: uploadResult.size,
+        numero_autorizacion: numeroAutorizacion,
+        fecha_autorizacion: fechaAutorizacion,
+        estado: 'GENERADO',
+      });
+
+      await creditNotePDF.save();
+      console.log(`✅ PDF de nota de crédito guardado: ${uploadResult.url}`);
+    } catch (error) {
+      console.error('❌ Error generating credit note PDF:', error);
+
+      try {
+        const errorPDF = new CreditNotePDF({
+          nota_credito_id: notaCredito._id,
+          claveAcceso: notaCredito.clave_acceso,
+          pdf_url: '',
+          pdf_public_id: '',
+          pdf_provider: 'error',
+          tamano_archivo: 0,
+          numero_autorizacion: notaCredito.clave_acceso,
+          fecha_autorizacion: new Date(),
+          estado: 'ERROR',
+        });
+
+        await errorPDF.save();
+      } catch (dbError) {
+        console.error('❌ Error saving credit note PDF error record:', dbError);
+      }
+    }
+  }
+}

--- a/src/services/debit-note.service.ts
+++ b/src/services/debit-note.service.ts
@@ -1,0 +1,364 @@
+import { DebitNoteRequest } from '../interfaces/debit-note.interface';
+import { convertirFecha, generarClaveAcceso } from '../utils/invoice.utils';
+import { generarXMLNotaDebito } from '../utils/xml.utils';
+import { firmarXML } from '../utils/firma.utils';
+import { enviarComprobanteSRI, autorizarComprobanteSRI, AutorizacionSRI, RespuestaSRI } from '../utils/sri.utils';
+import { generateDebitNotePDF } from '../utils/pdf.utils';
+import { PDFStorageFactory } from './storage';
+import { InvoiceService } from './invoice.service';
+import DebitNote from '../models/DebitNote';
+import DebitNotePDF from '../models/DebitNotePDF';
+import Invoice from '../models/Invoice';
+import IssuingCompany from '../models/IssuingCompany';
+import { IClient } from '../models/Client';
+import fs from 'fs';
+
+/**
+ * Servicio para manejar todas las operaciones relacionadas con notas de débito (codDoc 05)
+ */
+export class DebitNoteService {
+  /**
+   * Valida que los datos básicos de una nota de débito estén presentes
+   */
+  static validarDatosNotaDebito(datos: DebitNoteRequest): boolean {
+    return !!(
+      datos.infoTributaria &&
+      datos.infoNotaDebito &&
+      datos.motivos &&
+      datos.motivos.length > 0 &&
+      datos.infoNotaDebito.numDocModificado &&
+      datos.infoNotaDebito.impuestos &&
+      datos.infoNotaDebito.impuestos.length > 0 &&
+      datos.infoNotaDebito.pagos &&
+      datos.infoNotaDebito.pagos.length > 0
+    );
+  }
+
+  /**
+   * Genera el siguiente secuencial de nota de débito para una empresa
+   */
+  static async generarSecuencial(rucCompany: string): Promise<string> {
+    const empresa = await IssuingCompany.findOne({ ruc: rucCompany });
+    if (!empresa) {
+      throw new Error(`Empresa with RUC ${rucCompany} not found`);
+    }
+
+    const ultimaNota = await DebitNote.findOne({
+      empresa_emisora_id: empresa._id,
+    }).sort({ secuencial: -1 });
+
+    let secuencial = '000000001';
+    if (ultimaNota) {
+      const siguiente = parseInt(ultimaNota.secuencial) + 1;
+      secuencial = siguiente.toString().padStart(9, '0');
+    }
+    return secuencial;
+  }
+
+  /**
+   * Valida y resuelve todas las entidades necesarias para emitir la nota de débito
+   */
+  static async procesarNotaDebitoCompleta(datos: DebitNoteRequest) {
+    if (!this.validarDatosNotaDebito(datos)) {
+      throw new Error('Datos de nota de débito inválidos o incompletos');
+    }
+
+    const tipoIdent = await InvoiceService.buscarTipoIdentificacion(datos.infoNotaDebito.tipoIdentificacionComprador);
+    if (!tipoIdent) {
+      throw new Error('Identification type not found');
+    }
+
+    const empresa = await InvoiceService.buscarIssuingCompany(datos.infoTributaria.ruc);
+    if (!empresa) {
+      throw new Error('Empresa emisora no encontrada');
+    }
+
+    const cliente = await InvoiceService.buscarClient(datos.infoNotaDebito.identificacionComprador);
+    if (!cliente) {
+      throw new Error('Client not found');
+    }
+
+    const secuencial = await this.generarSecuencial(empresa.ruc);
+    const fechaEmision = convertirFecha(datos.infoNotaDebito.fechaEmision);
+    const fechaEmisionDocSustento = convertirFecha(datos.infoNotaDebito.fechaEmisionDocSustento);
+
+    if (isNaN(fechaEmision.getTime()) || isNaN(fechaEmisionDocSustento.getTime())) {
+      throw new Error('Invalid date format');
+    }
+
+    // Optional link to the modified invoice when it exists in this system
+    const facturaModificada = await Invoice.findOne({
+      empresa_emisora_id: empresa._id,
+      secuencial: datos.infoNotaDebito.numDocModificado.split('-').pop(),
+    });
+
+    return {
+      empresa,
+      cliente,
+      secuencial,
+      fechaEmision,
+      fechaEmisionDocSustento,
+      facturaModificada,
+    };
+  }
+
+  /**
+   * Procesa y guarda una nota de débito completa,
+   * y dispara el envío asíncrono al SRI
+   * @param datos Los datos de la nota de débito recibidos del cliente
+   * @returns La nota de débito creada
+   */
+  static async crearNotaDebitoCompleta(datos: DebitNoteRequest) {
+    const { empresa, cliente, secuencial, fechaEmision, fechaEmisionDocSustento, facturaModificada } =
+      await this.procesarNotaDebitoCompleta(datos);
+
+    const serie = `${empresa.codigo_establecimiento}${empresa.punto_emision}`;
+    const claveAcceso = generarClaveAcceso({
+      fecha: fechaEmision,
+      tipoComprobante: '05',
+      ruc: empresa.ruc,
+      ambiente: empresa.tipo_ambiente.toString(),
+      serie,
+      secuencial,
+      codigoNumerico: Math.floor(10000000 + Math.random() * 89999999).toString(),
+      tipoEmision: empresa.tipo_emision.toString(),
+    });
+
+    const totalSinImpuestos = parseFloat(datos.infoNotaDebito.totalSinImpuestos);
+    const totalImpuestos = datos.infoNotaDebito.impuestos.reduce((s, i) => s + parseFloat(i.impuesto.valor), 0);
+    const valorTotal = parseFloat(datos.infoNotaDebito.valorTotal);
+
+    const xml = generarXMLNotaDebito(datos, empresa, cliente, claveAcceso, secuencial);
+
+    const notaDebito = new DebitNote({
+      empresa_emisora_id: empresa._id,
+      cliente_id: cliente._id,
+      factura_modificada_id: facturaModificada?._id,
+      fecha_emision: fechaEmision,
+      clave_acceso: claveAcceso,
+      secuencial,
+      estado: 'CREADA',
+      cod_doc_modificado: datos.infoNotaDebito.codDocModificado,
+      num_doc_modificado: datos.infoNotaDebito.numDocModificado,
+      fecha_emision_doc_sustento: fechaEmisionDocSustento,
+      total_sin_impuestos: totalSinImpuestos,
+      total_impuestos: totalImpuestos,
+      valor_total: valorTotal,
+      motivos: datos.motivos.map((m) => ({ razon: m.motivo.razon, valor: parseFloat(m.motivo.valor) })),
+      xml,
+      sri_estado: 'PENDIENTE',
+      datos_originales: JSON.stringify(datos),
+    });
+
+    await notaDebito.save();
+
+    this.procesarEnvioSRI(notaDebito, empresa, cliente, datos).catch((error) => {
+      console.error('Error in asynchronous SRI sending process:', error);
+    });
+
+    return {
+      nota_debito: notaDebito,
+      xml: notaDebito.xml,
+      xml_firmado: notaDebito.xml_firmado || null,
+      respuesta_sri: null,
+    };
+  }
+
+  /**
+   * Procesa el envío asíncrono de la nota de débito al SRI:
+   * firma XAdES-BES, recepción y consulta de autorización
+   */
+  static async procesarEnvioSRI(
+    notaDebito: any,
+    empresa: any,
+    cliente: IClient,
+    datos: DebitNoteRequest,
+  ): Promise<void> {
+    let respuestaSRI: RespuestaSRI | null = null;
+
+    try {
+      const p12Path = empresa.certificatePath;
+      const p12Password = empresa.certificatePassword || '';
+
+      if (!p12Path || !fs.existsSync(p12Path)) {
+        notaDebito.sri_estado = 'ERROR_FIRMA';
+        notaDebito.sri_mensajes = { mensaje: 'Certificate not found for signing' };
+        await notaDebito.save();
+        return;
+      }
+
+      try {
+        const diagnosis = await InvoiceService.diagnoseP12Certificate(p12Path, p12Password);
+        if (!diagnosis.isValidP12) {
+          throw new Error(`El archivo P12 no es válido: ${diagnosis.error}`);
+        }
+
+        let workingPassword = p12Password;
+        const passwordVerification = await InvoiceService.verifyP12Password(p12Path, p12Password);
+        if (!passwordVerification.valid) {
+          const passwordSearch = await InvoiceService.findWorkingP12Password(p12Path, p12Password);
+          if (passwordSearch.password === null) {
+            throw new Error(`Error de contraseña del certificado P12: ${passwordVerification.error}`);
+          }
+          workingPassword = passwordSearch.password;
+        }
+
+        const xmlFirmado = await firmarXML(notaDebito.xml, p12Path, workingPassword, '05');
+
+        notaDebito.xml_firmado = xmlFirmado;
+        notaDebito.sri_fecha_envio = new Date();
+        await notaDebito.save();
+
+        respuestaSRI = await enviarComprobanteSRI(xmlFirmado);
+
+        notaDebito.sri_fecha_respuesta = new Date();
+        notaDebito.sri_estado = respuestaSRI.estado;
+        if (respuestaSRI.mensajes) {
+          notaDebito.sri_mensajes = respuestaSRI.mensajes;
+        }
+        await notaDebito.save();
+
+        if (respuestaSRI.estado === 'RECIBIDA') {
+          console.log(
+            `✅ NOTA DE DÉBITO RECIBIDA POR SRI - ID: ${notaDebito._id}, Clave: ${notaDebito.clave_acceso}, Secuencial: ${notaDebito.secuencial}`,
+          );
+          await this.generarPDFNotaDebito(notaDebito, empresa, cliente, datos);
+          this.programarConsultaAutorizacion(String(notaDebito._id));
+        } else {
+          console.log(`⚠️ SRI Estado: ${respuestaSRI.estado} - Nota de débito ID: ${notaDebito._id}`);
+        }
+      } catch (error: any) {
+        console.error('Error during certificate processing or signing:', error.message);
+        notaDebito.sri_estado = 'ERROR_FIRMA';
+        notaDebito.sri_mensajes = { error: error.message };
+        await notaDebito.save();
+      }
+    } catch (error: any) {
+      console.error('Error during signing or sending to SRI:', error.message);
+      notaDebito.sri_estado = 'ERROR_PROCESO';
+      notaDebito.sri_mensajes = { error: error.message };
+      await notaDebito.save();
+    }
+  }
+
+  /**
+   * Programa consultas de autorización al SRI con reintentos
+   */
+  static programarConsultaAutorizacion(notaDebitoId: string, intento = 1, maxIntentos = 3, delayMs = 5000): void {
+    const timer = setTimeout(async () => {
+      try {
+        const resultado = await DebitNoteService.consultarAutorizacionSRI(notaDebitoId);
+        const pendiente = !resultado || (resultado.estado !== 'AUTORIZADO' && resultado.estado !== 'NO AUTORIZADO');
+
+        if (pendiente && intento < maxIntentos) {
+          DebitNoteService.programarConsultaAutorizacion(notaDebitoId, intento + 1, maxIntentos, delayMs);
+        }
+      } catch (error: any) {
+        console.error('Error en la consulta de autorización automática:', error.message);
+      }
+    }, delayMs);
+
+    timer.unref?.();
+  }
+
+  /**
+   * Consulta el estado de autorización de una nota de débito ya recibida por el SRI
+   * y actualiza el documento con el resultado
+   */
+  static async consultarAutorizacionSRI(notaDebitoId: string): Promise<AutorizacionSRI | null> {
+    try {
+      const notaDebito = await DebitNote.findById(notaDebitoId);
+      if (!notaDebito || !notaDebito.clave_acceso) {
+        throw new Error('Nota de débito no encontrada o sin clave de acceso');
+      }
+
+      const respuesta = await autorizarComprobanteSRI(notaDebito.clave_acceso);
+
+      notaDebito.sri_estado = respuesta.estado;
+      notaDebito.sri_fecha_respuesta = new Date();
+      if (respuesta.mensajes) {
+        notaDebito.sri_mensajes = respuesta.mensajes;
+      }
+
+      if (respuesta.estado === 'AUTORIZADO') {
+        notaDebito.estado = 'AUTORIZADA';
+        notaDebito.autorizacion_numero = respuesta.numeroAutorizacion || notaDebito.clave_acceso;
+        notaDebito.fecha_autorizacion = respuesta.fechaAutorizacion
+          ? new Date(respuesta.fechaAutorizacion)
+          : new Date();
+        console.log(`✅ NOTA DE DÉBITO AUTORIZADA POR SRI - Secuencial: ${notaDebito.secuencial}`);
+      }
+
+      await notaDebito.save();
+      return respuesta;
+    } catch (error: any) {
+      console.error('Error al consultar autorización SRI:', error.message);
+      return null;
+    }
+  }
+
+  /**
+   * Genera y almacena el PDF (RIDE) de una nota de débito recibida por el SRI
+   */
+  static async generarPDFNotaDebito(
+    notaDebito: any,
+    empresa: any,
+    cliente: IClient,
+    datos: DebitNoteRequest,
+  ): Promise<void> {
+    try {
+      const numeroAutorizacion = notaDebito.clave_acceso;
+      const fechaAutorizacion = notaDebito.sri_fecha_respuesta || new Date();
+
+      const pdfBuffer = await generateDebitNotePDF({
+        notaDebito: datos,
+        empresa,
+        cliente,
+        claveAcceso: notaDebito.clave_acceso,
+        secuencial: notaDebito.secuencial,
+        fechaEmision: notaDebito.fecha_emision,
+        numeroAutorizacion,
+        fechaAutorizacion,
+      });
+
+      const storage = PDFStorageFactory.create();
+      const filename = `nota_debito_${notaDebito.secuencial}_${notaDebito.clave_acceso}`;
+      const uploadResult = await storage.upload(pdfBuffer, filename);
+
+      const debitNotePDF = new DebitNotePDF({
+        nota_debito_id: notaDebito._id,
+        claveAcceso: notaDebito.clave_acceso,
+        pdf_url: uploadResult.url,
+        pdf_public_id: uploadResult.publicId,
+        pdf_provider: uploadResult.provider,
+        tamano_archivo: uploadResult.size,
+        numero_autorizacion: numeroAutorizacion,
+        fecha_autorizacion: fechaAutorizacion,
+        estado: 'GENERADO',
+      });
+
+      await debitNotePDF.save();
+      console.log(`✅ PDF de nota de débito guardado: ${uploadResult.url}`);
+    } catch (error) {
+      console.error('❌ Error generating debit note PDF:', error);
+
+      try {
+        const errorPDF = new DebitNotePDF({
+          nota_debito_id: notaDebito._id,
+          claveAcceso: notaDebito.clave_acceso,
+          pdf_url: '',
+          pdf_public_id: '',
+          pdf_provider: 'error',
+          tamano_archivo: 0,
+          numero_autorizacion: notaDebito.clave_acceso,
+          fecha_autorizacion: new Date(),
+          estado: 'ERROR',
+        });
+
+        await errorPDF.save();
+      } catch (dbError) {
+        console.error('❌ Error saving debit note PDF error record:', dbError);
+      }
+    }
+  }
+}

--- a/src/services/invoice.service.ts
+++ b/src/services/invoice.service.ts
@@ -2,7 +2,7 @@ import { CreateInvoiceDTO, InvoiceRequest, ProductDetail, AccessKeyDTO } from '.
 import { convertirFecha, generarClaveAcceso } from '../utils/invoice.utils';
 import { generarXMLFactura } from '../utils/xml.utils';
 import { firmarXML } from '../utils/firma.utils';
-import { enviarComprobanteSRI, RespuestaSRI } from '../utils/sri.utils';
+import { enviarComprobanteSRI, autorizarComprobanteSRI, RespuestaSRI, AutorizacionSRI } from '../utils/sri.utils';
 import { generateInvoicePDF } from '../utils/pdf.utils';
 import { PDFStorageFactory } from './storage';
 import Invoice from '../models/Invoice';
@@ -367,8 +367,8 @@ export class InvoiceService {
             }
           }
 
-          const pemPath = await InvoiceService.convertP12ToPem(p12Path, workingPassword);
-          const xmlFirmado = await firmarXML(factura.xml, pemPath, workingPassword);
+          // Sign directly from the P12 using the SRI-compliant XAdES-BES signer
+          const xmlFirmado = await firmarXML(factura.xml, p12Path, workingPassword, '01');
 
           factura.xml_firmado = xmlFirmado;
           await factura.save();
@@ -391,6 +391,7 @@ export class InvoiceService {
                 `✅ FACTURA RECIBIDA POR SRI - ID: ${factura._id}, Clave: ${factura.clave_acceso}, Secuencial: ${factura.secuencial}`,
               );
               await this.generarPDFFactura(factura, empresa, cliente, productos, datosFactura);
+              this.programarConsultaAutorizacion(String(factura._id));
             } else {
               console.log(`⚠️ SRI Estado: ${respuestaSRI.estado} - Factura ID: ${factura._id}`);
             }
@@ -622,6 +623,69 @@ export class InvoiceService {
       } catch (dbError) {
         console.error('❌ Error saving PDF error record:', dbError);
       }
+    }
+  }
+
+  /**
+   * Programa consultas de autorización al SRI con reintentos.
+   * En el esquema offline la autorización es asíncrona: tras la recepción,
+   * el comprobante puede tardar unos segundos en ser autorizado.
+   * @param facturaId ID de la factura a consultar
+   * @param intento Número de intento actual
+   * @param maxIntentos Número máximo de intentos
+   * @param delayMs Espera entre intentos en milisegundos
+   */
+  static programarConsultaAutorizacion(facturaId: string, intento = 1, maxIntentos = 3, delayMs = 5000): void {
+    const timer = setTimeout(async () => {
+      try {
+        const resultado = await InvoiceService.consultarAutorizacionSRI(facturaId);
+        const pendiente = !resultado || (resultado.estado !== 'AUTORIZADO' && resultado.estado !== 'NO AUTORIZADO');
+
+        if (pendiente && intento < maxIntentos) {
+          InvoiceService.programarConsultaAutorizacion(facturaId, intento + 1, maxIntentos, delayMs);
+        }
+      } catch (error: any) {
+        console.error('Error en la consulta de autorización automática:', error.message);
+      }
+    }, delayMs);
+
+    // Do not keep the process alive because of the scheduled check
+    timer.unref?.();
+  }
+
+  /**
+   * Consulta el estado de autorización de una factura ya recibida por el SRI
+   * y actualiza el documento con el resultado.
+   * En el esquema offline el número de autorización es la propia clave de acceso.
+   * @param facturaId ID de la factura a consultar
+   */
+  static async consultarAutorizacionSRI(facturaId: string): Promise<AutorizacionSRI | null> {
+    try {
+      const factura = await Invoice.findById(facturaId);
+      if (!factura || !factura.clave_acceso) {
+        throw new Error('Factura no encontrada o sin clave de acceso');
+      }
+
+      const respuesta = await autorizarComprobanteSRI(factura.clave_acceso);
+
+      factura.sri_estado = respuesta.estado;
+      factura.sri_fecha_respuesta = new Date();
+      if (respuesta.mensajes) {
+        factura.sri_mensajes = respuesta.mensajes;
+      }
+
+      if (respuesta.estado === 'AUTORIZADO') {
+        factura.estado = 'AUTORIZADA';
+        factura.autorizacion_numero = respuesta.numeroAutorizacion || factura.clave_acceso;
+        factura.fecha_autorizacion = respuesta.fechaAutorizacion ? new Date(respuesta.fechaAutorizacion) : new Date();
+        console.log(`✅ FACTURA AUTORIZADA POR SRI - Secuencial: ${factura.secuencial}`);
+      }
+
+      await factura.save();
+      return respuesta;
+    } catch (error: any) {
+      console.error('Error al consultar autorización SRI:', error.message);
+      return null;
     }
   }
 

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -418,6 +418,70 @@ export default {
         responses: { '200': { description: 'OK' }, '404': { description: 'Not found' } },
       },
     },
+    '/api/v1/debit-note': {
+      get: { tags: ['Debit Note CRUD'], summary: 'List Debit Notes', responses: { '200': { description: 'OK' } } },
+      post: {
+        tags: ['Debit Note CRUD'],
+        summary: 'Create Nota de Débito',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': { schema: { $ref: '#/components/schemas/NotaDebito' } },
+          },
+        },
+        responses: { '201': { description: 'Created' } },
+      },
+    },
+    '/api/v1/debit-note/complete': {
+      post: {
+        tags: ['Debit Note Processing'],
+        summary: 'Create Nota de Débito completa (XML, firma, envío y autorización SRI)',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': { schema: { $ref: '#/components/schemas/NotaDebitoComplete' } },
+          },
+        },
+        responses: {
+          '201': { description: 'Created' },
+          '400': { description: 'Validation error' },
+        },
+      },
+    },
+    '/api/v1/debit-note/{id}': {
+      get: {
+        tags: ['Debit Note CRUD'],
+        summary: 'Get Nota de Débito',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        responses: { '200': { description: 'OK' }, '404': { description: 'Not found' } },
+      },
+      put: {
+        tags: ['Debit Note CRUD'],
+        summary: 'Update Nota de Débito',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': { schema: { $ref: '#/components/schemas/NotaDebito' } },
+          },
+        },
+        responses: { '200': { description: 'Updated' }, '404': { description: 'Not found' } },
+      },
+      delete: {
+        tags: ['Debit Note CRUD'],
+        summary: 'Delete Nota de Débito',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        responses: { '200': { description: 'Deleted' }, '404': { description: 'Not found' } },
+      },
+    },
+    '/api/v1/debit-note/{id}/pdf': {
+      get: {
+        tags: ['Debit Note Processing'],
+        summary: 'Get Nota de Débito PDF (RIDE) info',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        responses: { '200': { description: 'OK' }, '404': { description: 'Not found' } },
+      },
+    },
     '/api/v1/invoice-detail': {
       get: {
         tags: ['Invoice Detail Management'],
@@ -876,6 +940,91 @@ export default {
         required: ['codigo', 'codigoPorcentaje', 'tarifa', 'baseImponible', 'valor'],
       },
       NotaCredito: { type: 'object' },
+      NotaDebito: { type: 'object' },
+      NotaDebitoComplete: {
+        type: 'object',
+        properties: {
+          nota_debito: { $ref: '#/components/schemas/NotaDebitoBody' },
+        },
+        required: ['nota_debito'],
+      },
+      NotaDebitoBody: {
+        type: 'object',
+        properties: {
+          infoTributaria: { $ref: '#/components/schemas/FacturaInfoTributaria' },
+          infoNotaDebito: { $ref: '#/components/schemas/NotaDebitoInfo' },
+          motivos: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/NotaDebitoMotivoItem' },
+          },
+        },
+        required: ['infoTributaria', 'infoNotaDebito', 'motivos'],
+      },
+      NotaDebitoInfo: {
+        type: 'object',
+        properties: {
+          fechaEmision: { type: 'string', example: '17/05/2025', description: 'Formato DD/MM/YYYY' },
+          tipoIdentificacionComprador: { type: 'string', example: '05' },
+          identificacionComprador: { type: 'string', example: '0106079783' },
+          razonSocialComprador: { type: 'string', example: 'Juan Pérez' },
+          codDocModificado: { type: 'string', example: '01', description: 'Tabla 3 SRI. 01 = Factura' },
+          numDocModificado: { type: 'string', example: '001-001-000000123' },
+          fechaEmisionDocSustento: { type: 'string', example: '10/05/2025', description: 'Formato DD/MM/YYYY' },
+          totalSinImpuestos: { type: 'string', example: '50.00' },
+          impuestos: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/FacturaDetalleImpuesto' },
+            description: 'La tarifa de IVA corresponde a la fecha de emisión del documento de sustento',
+          },
+          valorTotal: { type: 'string', example: '57.50' },
+          pagos: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/NotaDebitoPagoItem' },
+          },
+        },
+        required: [
+          'fechaEmision',
+          'tipoIdentificacionComprador',
+          'identificacionComprador',
+          'codDocModificado',
+          'numDocModificado',
+          'fechaEmisionDocSustento',
+          'totalSinImpuestos',
+          'impuestos',
+          'valorTotal',
+          'pagos',
+        ],
+      },
+      NotaDebitoPagoItem: {
+        type: 'object',
+        properties: {
+          pago: {
+            type: 'object',
+            properties: {
+              formaPago: { type: 'string', example: '20', description: 'Tabla 24 SRI' },
+              total: { type: 'string', example: '57.50' },
+              plazo: { type: 'string', example: '15' },
+              unidadTiempo: { type: 'string', example: 'dias' },
+            },
+            required: ['formaPago', 'total'],
+          },
+        },
+        required: ['pago'],
+      },
+      NotaDebitoMotivoItem: {
+        type: 'object',
+        properties: {
+          motivo: {
+            type: 'object',
+            properties: {
+              razon: { type: 'string', example: 'Interés por mora' },
+              valor: { type: 'string', example: '50.00' },
+            },
+            required: ['razon', 'valor'],
+          },
+        },
+        required: ['motivo'],
+      },
       NotaCreditoComplete: {
         type: 'object',
         properties: {

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -354,6 +354,70 @@ export default {
         responses: { '200': { description: 'Deleted' } },
       },
     },
+    '/api/v1/credit-note': {
+      get: { tags: ['Credit Note CRUD'], summary: 'List Credit Notes', responses: { '200': { description: 'OK' } } },
+      post: {
+        tags: ['Credit Note CRUD'],
+        summary: 'Create Nota de Crédito',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': { schema: { $ref: '#/components/schemas/NotaCredito' } },
+          },
+        },
+        responses: { '201': { description: 'Created' } },
+      },
+    },
+    '/api/v1/credit-note/complete': {
+      post: {
+        tags: ['Credit Note Processing'],
+        summary: 'Create Nota de Crédito with details (XML, firma, envío y autorización SRI)',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': { schema: { $ref: '#/components/schemas/NotaCreditoComplete' } },
+          },
+        },
+        responses: {
+          '201': { description: 'Created' },
+          '400': { description: 'Validation error' },
+        },
+      },
+    },
+    '/api/v1/credit-note/{id}': {
+      get: {
+        tags: ['Credit Note CRUD'],
+        summary: 'Get Nota de Crédito',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        responses: { '200': { description: 'OK' }, '404': { description: 'Not found' } },
+      },
+      put: {
+        tags: ['Credit Note CRUD'],
+        summary: 'Update Nota de Crédito',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': { schema: { $ref: '#/components/schemas/NotaCredito' } },
+          },
+        },
+        responses: { '200': { description: 'Updated' }, '404': { description: 'Not found' } },
+      },
+      delete: {
+        tags: ['Credit Note CRUD'],
+        summary: 'Delete Nota de Crédito',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        responses: { '200': { description: 'Deleted' }, '404': { description: 'Not found' } },
+      },
+    },
+    '/api/v1/credit-note/{id}/pdf': {
+      get: {
+        tags: ['Credit Note Processing'],
+        summary: 'Get Nota de Crédito PDF (RIDE) info',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        responses: { '200': { description: 'OK' }, '404': { description: 'Not found' } },
+      },
+    },
     '/api/v1/invoice-detail': {
       get: {
         tags: ['Invoice Detail Management'],
@@ -804,12 +868,83 @@ export default {
         type: 'object',
         properties: {
           codigo: { type: 'string', example: '2' },
-          codigoPorcentaje: { type: 'string', example: '2' },
-          tarifa: { type: 'string', example: '12.00' },
+          codigoPorcentaje: { type: 'string', example: '4', description: 'Tabla 17 SRI. 4 = IVA 15%' },
+          tarifa: { type: 'string', example: '15.00' },
           baseImponible: { type: 'string', example: '100.00' },
-          valor: { type: 'string', example: '12.00' },
+          valor: { type: 'string', example: '15.00' },
         },
         required: ['codigo', 'codigoPorcentaje', 'tarifa', 'baseImponible', 'valor'],
+      },
+      NotaCredito: { type: 'object' },
+      NotaCreditoComplete: {
+        type: 'object',
+        properties: {
+          nota_credito: { $ref: '#/components/schemas/NotaCreditoBody' },
+        },
+        required: ['nota_credito'],
+      },
+      NotaCreditoBody: {
+        type: 'object',
+        properties: {
+          infoTributaria: { $ref: '#/components/schemas/FacturaInfoTributaria' },
+          infoNotaCredito: { $ref: '#/components/schemas/NotaCreditoInfo' },
+          detalles: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/NotaCreditoDetalleItem' },
+          },
+        },
+        required: ['infoTributaria', 'infoNotaCredito', 'detalles'],
+      },
+      NotaCreditoInfo: {
+        type: 'object',
+        properties: {
+          fechaEmision: { type: 'string', example: '17/05/2025', description: 'Formato DD/MM/YYYY' },
+          tipoIdentificacionComprador: { type: 'string', example: '05' },
+          identificacionComprador: { type: 'string', example: '0106079783' },
+          razonSocialComprador: { type: 'string', example: 'Juan Pérez' },
+          codDocModificado: { type: 'string', example: '01', description: 'Tabla 3 SRI. 01 = Factura' },
+          numDocModificado: { type: 'string', example: '001-001-000000123' },
+          fechaEmisionDocSustento: { type: 'string', example: '10/05/2025', description: 'Formato DD/MM/YYYY' },
+          totalSinImpuestos: { type: 'string', example: '100.00' },
+          valorModificacion: { type: 'string', example: '115.00' },
+          moneda: { type: 'string', example: 'DOLAR' },
+          motivo: { type: 'string', example: 'DEVOLUCIÓN' },
+        },
+        required: [
+          'fechaEmision',
+          'tipoIdentificacionComprador',
+          'identificacionComprador',
+          'codDocModificado',
+          'numDocModificado',
+          'fechaEmisionDocSustento',
+          'totalSinImpuestos',
+          'valorModificacion',
+          'motivo',
+        ],
+      },
+      NotaCreditoDetalleItem: {
+        type: 'object',
+        properties: {
+          detalle: { $ref: '#/components/schemas/NotaCreditoDetalleData' },
+        },
+        required: ['detalle'],
+      },
+      NotaCreditoDetalleData: {
+        type: 'object',
+        properties: {
+          codigoInterno: { type: 'string', example: 'P001' },
+          codigoAdicional: { type: 'string', example: 'A001' },
+          descripcion: { type: 'string', example: 'Laptop Lenovo' },
+          cantidad: { type: 'string', example: '1.00' },
+          precioUnitario: { type: 'string', example: '100.00' },
+          descuento: { type: 'string', example: '0.00' },
+          precioTotalSinImpuesto: { type: 'string', example: '100.00' },
+          impuestos: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/FacturaDetalleImpuesto' },
+          },
+        },
+        required: ['codigoInterno', 'descripcion', 'cantidad', 'precioUnitario', 'precioTotalSinImpuesto', 'impuestos'],
       },
       UserRegistration: {
         type: 'object',

--- a/src/testApp.ts
+++ b/src/testApp.ts
@@ -6,6 +6,7 @@ import clientRoutes from './routes/client';
 import productRoutes from './routes/product';
 import invoiceRoutes from './routes/invoice';
 import creditNoteRoutes from './routes/creditNote';
+import debitNoteRoutes from './routes/debitNote';
 import invoiceDetailRoutes from './routes/invoiceDetail';
 import verifyToken from './middleware/verifyToken';
 
@@ -20,6 +21,7 @@ export function createApp() {
   app.use('/api/v1/product', productRoutes);
   app.use('/api/v1/invoice', invoiceRoutes);
   app.use('/api/v1/credit-note', creditNoteRoutes);
+  app.use('/api/v1/debit-note', debitNoteRoutes);
   app.use('/api/v1/invoice-detail', invoiceDetailRoutes);
   return app;
 }

--- a/src/testApp.ts
+++ b/src/testApp.ts
@@ -5,6 +5,7 @@ import issuingCompanyRoutes from './routes/issuingCompany';
 import clientRoutes from './routes/client';
 import productRoutes from './routes/product';
 import invoiceRoutes from './routes/invoice';
+import creditNoteRoutes from './routes/creditNote';
 import invoiceDetailRoutes from './routes/invoiceDetail';
 import verifyToken from './middleware/verifyToken';
 
@@ -18,6 +19,7 @@ export function createApp() {
   app.use('/api/v1/client', clientRoutes);
   app.use('/api/v1/product', productRoutes);
   app.use('/api/v1/invoice', invoiceRoutes);
+  app.use('/api/v1/credit-note', creditNoteRoutes);
   app.use('/api/v1/invoice-detail', invoiceDetailRoutes);
   return app;
 }

--- a/src/utils/firma.utils.ts
+++ b/src/utils/firma.utils.ts
@@ -1,89 +1,129 @@
 import fs from 'fs';
-import { DOMParser } from '@xmldom/xmldom';
-import { SignedXml } from 'xml-crypto';
 import forge from 'node-forge';
+import {
+  signInvoiceXml,
+  signCreditNoteXml,
+  signDebitNoteXml,
+  signDeliveryGuideXml,
+  signWithholdingCertificateXml,
+} from 'ec-sri-invoice-signer';
 
-interface KeyInfoProvider {
-  getKeyInfo(): string;
+/**
+ * Códigos de tipo de documento según la tabla 3 de la Ficha Técnica del SRI
+ */
+export type TipoDocumento = '01' | '04' | '05' | '06' | '07';
+
+type SignerFn = (xml: string, p12Data: Buffer, options?: { pkcs12Password?: string }) => string;
+
+const FIRMADORES: Record<TipoDocumento, SignerFn> = {
+  '01': signInvoiceXml,
+  '04': signCreditNoteXml,
+  '05': signDebitNoteXml,
+  '06': signDeliveryGuideXml,
+  '07': signWithholdingCertificateXml,
+};
+
+/**
+ * Determines whether a certificate is a CA certificate (part of the chain, not the signer)
+ */
+function esCertificadoCA(cert: forge.pki.Certificate): boolean {
+  const basicConstraints = cert.getExtension('basicConstraints') as { cA?: boolean } | null;
+  if (basicConstraints && typeof basicConstraints.cA === 'boolean') {
+    return basicConstraints.cA;
+  }
+  // Fallback heuristic for certificates without basicConstraints
+  const cn = cert.subject.getField({ shortName: 'CN' })?.value || '';
+  return cn.includes('AUTORIDAD') || cn.startsWith('AC ');
 }
 
 /**
- * Firma un documento XML usando un certificado PEM
- * @param xmlString String del XML a firmar
- * @param pemPath Ruta al archivo PEM del certificado
- * @param password Contraseña del certificado (opcional para PEM)
+ * Extracts the signing certificate and its private key from a P12 file.
+ * Ecuadorian P12 files (BCE, Security Data, etc.) usually bundle the CA chain,
+ * so the signer certificate is selected by matching the private key's localKeyId,
+ * with a fallback to the first non-CA certificate.
+ */
+function extraerCertificadoFirmante(
+  p12Buffer: Buffer,
+  password: string,
+): { certificado: forge.pki.Certificate; clavePrivada: forge.pki.PrivateKey } {
+  const p12Der = forge.util.decode64(p12Buffer.toString('base64'));
+  const p12Asn1 = forge.asn1.fromDer(p12Der);
+  const p12 = forge.pkcs12.pkcs12FromAsn1(p12Asn1, true, password);
+
+  const certBags = p12.getBags({ bagType: forge.pki.oids.certBag })[forge.pki.oids.certBag] || [];
+  const keyBags = [
+    ...(p12.getBags({ bagType: forge.pki.oids.pkcs8ShroudedKeyBag })[forge.pki.oids.pkcs8ShroudedKeyBag] || []),
+    ...(p12.getBags({ bagType: forge.pki.oids.keyBag })[forge.pki.oids.keyBag] || []),
+  ];
+
+  const keyBag = keyBags[0];
+  if (!keyBag || !keyBag.key) {
+    throw new Error('No se encontró una clave privada en el archivo P12');
+  }
+
+  const keyLocalKeyId = keyBag.attributes?.localKeyId?.[0];
+
+  // Preferred: certificate whose localKeyId matches the private key's localKeyId
+  let certificado: forge.pki.Certificate | undefined;
+  if (keyLocalKeyId) {
+    certificado = certBags.find((bag) => bag.cert && bag.attributes?.localKeyId?.[0] === keyLocalKeyId)?.cert as
+      | forge.pki.Certificate
+      | undefined;
+  }
+
+  // Fallback: first non-CA certificate
+  if (!certificado) {
+    certificado = certBags.find((bag) => bag.cert && !esCertificadoCA(bag.cert))?.cert as
+      | forge.pki.Certificate
+      | undefined;
+  }
+
+  // Last resort: first certificate available
+  if (!certificado) {
+    certificado = certBags[0]?.cert as forge.pki.Certificate | undefined;
+  }
+
+  if (!certificado) {
+    throw new Error('No se encontró el certificado de firma digital en el archivo P12');
+  }
+
+  return { certificado, clavePrivada: keyBag.key };
+}
+
+/**
+ * Firma un documento XML según el estándar XAdES-BES exigido por el SRI,
+ * usando la librería ec-sri-invoice-signer.
+ *
+ * Se reconstruye un P12 mínimo (certificado firmante + clave privada) para evitar
+ * ambigüedad cuando el archivo original incluye la cadena de certificados de la CA.
+ *
+ * @param xmlString String del XML a firmar (nodo raíz con id="comprobante")
+ * @param p12Path Ruta al archivo P12 del certificado digital
+ * @param password Contraseña del certificado P12
+ * @param tipoDocumento Código del tipo de documento (tabla 3 del SRI). Por defecto '01' (factura)
  * @returns String del XML firmado
  */
-export async function firmarXML(xmlString: string, pemPath: string, password: string): Promise<string> {
+export async function firmarXML(
+  xmlString: string,
+  p12Path: string,
+  password: string,
+  tipoDocumento: TipoDocumento = '01',
+): Promise<string> {
   try {
-    // Read PEM file
-    const pemData = fs.readFileSync(pemPath, 'utf8');
+    const p12Buffer = fs.readFileSync(p12Path);
+    const { certificado, clavePrivada } = extraerCertificadoFirmante(p12Buffer, password || '');
 
-    // Parse the PEM certificate
-    const certPart = pemData.split('-----BEGIN CERTIFICATE-----')[1]?.split('-----END CERTIFICATE-----')[0];
-    if (!certPart) {
-      throw new Error('No se pudo encontrar el certificado en el archivo PEM');
+    // Minimal P12 with only the signing certificate and its key
+    const p12MinimoAsn1 = forge.pkcs12.toPkcs12Asn1(clavePrivada, certificado, password || '');
+    const p12MinimoDer = forge.asn1.toDer(p12MinimoAsn1).getBytes();
+    const p12Minimo = Buffer.from(p12MinimoDer, 'binary');
+
+    const firmador = FIRMADORES[tipoDocumento];
+    if (!firmador) {
+      throw new Error(`Tipo de documento no soportado para firma: ${tipoDocumento}`);
     }
 
-    const certPem = `-----BEGIN CERTIFICATE-----${certPart}-----END CERTIFICATE-----`;
-
-    try {
-      const certificate = forge.pki.certificateFromPem(certPem);
-    } catch (e) {
-      console.error('Error parsing certificate:', e);
-      throw new Error('Error al parsear el certificado: ' + (e as Error).message);
-    }
-
-    // Extract the private key from the certificate
-    let privateKey;
-    let privateKeyPem = '';
-
-    // Check RSA PRIVATE KEY format
-    if (pemData.includes('-----BEGIN RSA PRIVATE KEY-----')) {
-      const rsaKeyPart = pemData.split('-----BEGIN RSA PRIVATE KEY-----')[1]?.split('-----END RSA PRIVATE KEY-----')[0];
-      if (rsaKeyPart) {
-        privateKeyPem = `-----BEGIN RSA PRIVATE KEY-----${rsaKeyPart}-----END RSA PRIVATE KEY-----`;
-        privateKey = privateKeyPem;
-      }
-    }
-    // Check PRIVATE KEY format
-    else if (pemData.includes('-----BEGIN PRIVATE KEY-----')) {
-      const keyPart = pemData.split('-----BEGIN PRIVATE KEY-----')[1]?.split('-----END PRIVATE KEY-----')[0];
-      if (keyPart) {
-        privateKeyPem = `-----BEGIN PRIVATE KEY-----${keyPart}-----END PRIVATE KEY-----`;
-        privateKey = privateKeyPem;
-      }
-    }
-
-    if (!privateKeyPem) {
-      throw new Error('No se encontró la clave privada en el archivo PEM');
-    }
-
-    const sig = new SignedXml({
-      privateKey: privateKey,
-      signatureAlgorithm: 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
-      canonicalizationAlgorithm: 'http://www.w3.org/TR/2001/REC-xml-c14n-20010315',
-    }) as any;
-
-    sig.addReference({
-      xpath: "//*[local-name(.)='factura']",
-      transforms: ['http://www.w3.org/2000/09/xmldsig#enveloped-signature'],
-      digestAlgorithm: 'http://www.w3.org/2000/09/xmldsig#sha1',
-    });
-
-    sig.keyInfoProvider = {
-      getKeyInfo(): string {
-        return `<X509Data><X509Certificate>${certPem
-          .replace('-----BEGIN CERTIFICATE-----', '')
-          .replace('-----END CERTIFICATE-----', '')
-          .replace(/\r?\n|\r/g, '')}</X509Certificate></X509Data>`;
-      },
-    } as KeyInfoProvider;
-
-    // Sign XML
-    const doc = new DOMParser().parseFromString(xmlString, 'text/xml');
-    sig.computeSignature(xmlString);
-    return sig.getSignedXml();
+    return firmador(xmlString, p12Minimo, { pkcs12Password: password || '' });
   } catch (error: any) {
     console.error('Error signing XML:', error.message);
     throw new Error(`Error al firmar XML: ${error.message}`);
@@ -91,7 +131,7 @@ export async function firmarXML(xmlString: string, pemPath: string, password: st
 }
 
 /**
- * Guarda un XML firmado en un archivo
+ * Guarda un XML firmado en el sistema de archivos
  */
 export function guardarXMLFirmado(xmlString: string, outputPath: string): void {
   fs.writeFileSync(outputPath, xmlString, { encoding: 'utf8' });

--- a/src/utils/pdf.utils.ts
+++ b/src/utils/pdf.utils.ts
@@ -4,6 +4,7 @@ import { IClient } from '../models/Client';
 import { IProduct } from '../models/Product';
 import { InvoiceRequest } from '../interfaces/invoice.interface';
 import { CreditNoteRequest } from '../interfaces/credit-note.interface';
+import { DebitNoteRequest } from '../interfaces/debit-note.interface';
 
 interface InvoiceData {
   factura: any;
@@ -31,6 +32,17 @@ export interface CreditNotePDFData {
   empresa: IIssuingCompany;
   cliente: IClient;
   productos: IProduct[];
+  claveAcceso: string;
+  secuencial: string;
+  fechaEmision: Date;
+  numeroAutorizacion: string;
+  fechaAutorizacion: Date;
+}
+
+export interface DebitNotePDFData {
+  notaDebito: DebitNoteRequest;
+  empresa: IIssuingCompany;
+  cliente: IClient;
   claveAcceso: string;
   secuencial: string;
   fechaEmision: Date;
@@ -437,6 +449,51 @@ export async function generateCreditNotePDF(data: CreditNotePDFData): Promise<Bu
       numero: info.numDocModificado,
       fechaEmision: info.fechaEmisionDocSustento,
       motivo: info.motivo,
+    },
+  };
+
+  return generateInvoicePDF(invoiceShapedData);
+}
+
+/**
+ * Generates a PDF buffer for a debit note (RIDE) reusing the shared document template.
+ * The motivos (surcharges) are rendered as the document line items.
+ */
+export async function generateDebitNotePDF(data: DebitNotePDFData): Promise<Buffer> {
+  const info = data.notaDebito.infoNotaDebito;
+  const motivoPrincipal = data.notaDebito.motivos[0]?.motivo.razon || '';
+
+  const invoiceShapedData: InvoiceData = {
+    factura: {
+      infoFactura: {
+        totalSinImpuestos: info.totalSinImpuestos,
+        importeTotal: info.valorTotal,
+      },
+      detalles: data.notaDebito.motivos.map((item) => ({
+        detalle: {
+          codigoPrincipal: '',
+          descripcion: item.motivo.razon,
+          cantidad: '1',
+          precioUnitario: item.motivo.valor,
+          precioTotalSinImpuesto: item.motivo.valor,
+          impuestos: info.impuestos,
+        },
+      })),
+    },
+    empresa: data.empresa,
+    cliente: data.cliente,
+    productos: data.notaDebito.motivos.map(() => ({}) as IProduct),
+    claveAcceso: data.claveAcceso,
+    secuencial: data.secuencial,
+    fechaEmision: data.fechaEmision,
+    numeroAutorizacion: data.numeroAutorizacion,
+    fechaAutorizacion: data.fechaAutorizacion,
+    tipoDocumento: 'NOTA DE DÉBITO',
+    docModificado: {
+      tipo: info.codDocModificado === '01' ? 'FACTURA' : info.codDocModificado,
+      numero: info.numDocModificado,
+      fechaEmision: info.fechaEmisionDocSustento,
+      motivo: motivoPrincipal,
     },
   };
 

--- a/src/utils/pdf.utils.ts
+++ b/src/utils/pdf.utils.ts
@@ -3,9 +3,31 @@ import { IIssuingCompany } from '../models/IssuingCompany';
 import { IClient } from '../models/Client';
 import { IProduct } from '../models/Product';
 import { InvoiceRequest } from '../interfaces/invoice.interface';
+import { CreditNoteRequest } from '../interfaces/credit-note.interface';
 
 interface InvoiceData {
   factura: any;
+  empresa: IIssuingCompany;
+  cliente: IClient;
+  productos: IProduct[];
+  claveAcceso: string;
+  secuencial: string;
+  fechaEmision: Date;
+  numeroAutorizacion: string;
+  fechaAutorizacion: Date;
+  /** Título del documento en el RIDE. Por defecto 'FACTURA' */
+  tipoDocumento?: string;
+  /** Información del documento que se modifica (solo notas de crédito/débito) */
+  docModificado?: {
+    tipo: string;
+    numero: string;
+    fechaEmision: string;
+    motivo: string;
+  };
+}
+
+export interface CreditNotePDFData {
+  notaCredito: CreditNoteRequest;
   empresa: IIssuingCompany;
   cliente: IClient;
   productos: IProduct[];
@@ -31,6 +53,22 @@ function generateInvoiceHTML(data: InvoiceData): string {
     numeroAutorizacion,
     fechaAutorizacion,
   } = data;
+
+  const tituloDocumento = data.tipoDocumento || 'FACTURA';
+  const tarifaIva = process.env.IVA || '15';
+  const filasDocModificado = data.docModificado
+    ? `
+          <tr>
+            <td class="label">Comprobante que se modifica</td>
+            <td>${data.docModificado.tipo} ${data.docModificado.numero}</td>
+            <td class="label">Fecha Emisión (Doc. Sustento)</td>
+            <td>${data.docModificado.fechaEmision}</td>
+          </tr>
+          <tr>
+            <td class="label">Razón de Modificación</td>
+            <td colspan="3">${data.docModificado.motivo}</td>
+          </tr>`
+    : '';
 
   return `
     <!DOCTYPE html>
@@ -177,7 +215,7 @@ function generateInvoiceHTML(data: InvoiceData): string {
               R.U.C.: ${empresa.ruc}
             </div>
             <div style="text-align: center; font-weight: bold; margin: 10px 0;">
-              FACTURA
+              ${tituloDocumento}
             </div>
             <div><strong>No.:</strong> ${empresa.codigo_establecimiento}-${empresa.punto_emision}-${secuencial}</div>
             <div style="margin: 10px 0;">
@@ -214,7 +252,7 @@ function generateInvoiceHTML(data: InvoiceData): string {
           <tr>
             <td class="label">Dirección</td>
             <td colspan="3">${cliente.direccion || 'N/A'}</td>
-          </tr>
+          </tr>${filasDocModificado}
         </table>
 
         <!-- Invoice Details -->
@@ -265,7 +303,7 @@ function generateInvoiceHTML(data: InvoiceData): string {
         <div class="totals-section">
           <table class="totals-table">
             <tr>
-              <td class="label">SUBTOTAL 12%</td>
+              <td class="label">SUBTOTAL ${tarifaIva}%</td>
               <td class="amount">$${parseFloat(factura.infoFactura.totalSinImpuestos).toFixed(2)}</td>
             </tr>
             <tr>
@@ -285,7 +323,7 @@ function generateInvoiceHTML(data: InvoiceData): string {
               <td class="amount">$0.00</td>
             </tr>
             <tr>
-              <td class="label">IVA 12%</td>
+              <td class="label">IVA ${tarifaIva}%</td>
               <td class="amount">$${(parseFloat(factura.infoFactura.importeTotal) - parseFloat(factura.infoFactura.totalSinImpuestos)).toFixed(2)}</td>
             </tr>
             <tr>
@@ -359,6 +397,50 @@ export async function generateInvoicePDF(invoiceData: InvoiceData): Promise<Buff
       await browser.close();
     }
   }
+}
+
+/**
+ * Generates a PDF buffer for a credit note (RIDE) reusing the shared document template
+ */
+export async function generateCreditNotePDF(data: CreditNotePDFData): Promise<Buffer> {
+  const info = data.notaCredito.infoNotaCredito;
+
+  // Map the credit note into the shared document template shape
+  const invoiceShapedData: InvoiceData = {
+    factura: {
+      infoFactura: {
+        totalSinImpuestos: info.totalSinImpuestos,
+        importeTotal: info.valorModificacion,
+      },
+      detalles: data.notaCredito.detalles.map((item) => ({
+        detalle: {
+          codigoPrincipal: item.detalle.codigoInterno,
+          descripcion: item.detalle.descripcion,
+          cantidad: item.detalle.cantidad,
+          precioUnitario: item.detalle.precioUnitario,
+          precioTotalSinImpuesto: item.detalle.precioTotalSinImpuesto,
+          impuestos: item.detalle.impuestos,
+        },
+      })),
+    },
+    empresa: data.empresa,
+    cliente: data.cliente,
+    productos: data.productos,
+    claveAcceso: data.claveAcceso,
+    secuencial: data.secuencial,
+    fechaEmision: data.fechaEmision,
+    numeroAutorizacion: data.numeroAutorizacion,
+    fechaAutorizacion: data.fechaAutorizacion,
+    tipoDocumento: 'NOTA DE CRÉDITO',
+    docModificado: {
+      tipo: info.codDocModificado === '01' ? 'FACTURA' : info.codDocModificado,
+      numero: info.numDocModificado,
+      fechaEmision: info.fechaEmisionDocSustento,
+      motivo: info.motivo,
+    },
+  };
+
+  return generateInvoicePDF(invoiceShapedData);
 }
 
 /**

--- a/src/utils/sri.utils.ts
+++ b/src/utils/sri.utils.ts
@@ -44,6 +44,15 @@ export interface RespuestaSRI {
   };
 }
 
+// Interface for SRI authorization response
+export interface AutorizacionSRI {
+  estado: string; // EX: AUTORIZADO, NO AUTORIZADO, EN PROCESO
+  numeroAutorizacion?: string;
+  fechaAutorizacion?: string;
+  ambiente?: string;
+  mensajes?: RespuestaSRI['mensajes'];
+}
+
 // WSDL URLs for SRI - now configurable via environment variables
 const WSDL_PRUEBAS_RECEPCION =
   process.env.SRI_RECEPCION_URL_PRUEBAS ||
@@ -53,12 +62,28 @@ const WSDL_PRODUCCION_RECEPCION =
   process.env.SRI_RECEPCION_URL_PRODUCCION ||
   'https://cel.sri.gob.ec/comprobantes-electronicos-ws/RecepcionComprobantesOffline?wsdl';
 
+const WSDL_PRUEBAS_AUTORIZACION =
+  process.env.SRI_AUTORIZACION_URL_PRUEBAS ||
+  'https://celcer.sri.gob.ec/comprobantes-electronicos-ws/AutorizacionComprobantesOffline?wsdl';
+
+const WSDL_PRODUCCION_AUTORIZACION =
+  process.env.SRI_AUTORIZACION_URL_PRODUCCION ||
+  'https://cel.sri.gob.ec/comprobantes-electronicos-ws/AutorizacionComprobantesOffline?wsdl';
+
 /**
  * Get the appropriate WSDL URL based on environment
  */
 function getWsdlUrl(): string {
   const environment = process.env.SRI_ENVIRONMENT || '1';
   return environment === '2' ? WSDL_PRODUCCION_RECEPCION : WSDL_PRUEBAS_RECEPCION;
+}
+
+/**
+ * Get the appropriate authorization WSDL URL based on environment
+ */
+function getAutorizacionWsdlUrl(): string {
+  const environment = process.env.SRI_ENVIRONMENT || '1';
+  return environment === '2' ? WSDL_PRODUCCION_AUTORIZACION : WSDL_PRUEBAS_AUTORIZACION;
 }
 
 /**
@@ -228,9 +253,165 @@ export async function enviarComprobanteSRI(xmlFirmado: string): Promise<Respuest
   }
 }
 
-// Helper to remove XML tag prefixes when parsing (if using xml2js)
-/*
-function stripPrefix(name: string): string {
-  return name.substring(name.indexOf(':') + 1);
+/**
+ * Extracts the mensajes block from an XML element, if present
+ */
+function extraerMensajes(parent: Element | Document): RespuestaSRI['mensajes'] | undefined {
+  const mensajesElements = parent.getElementsByTagName('mensaje');
+  if (mensajesElements.length === 0) return undefined;
+
+  const mensajes = [];
+  for (let i = 0; i < mensajesElements.length; i++) {
+    const mensajeElement = mensajesElements[i];
+
+    // Skip the inner <mensaje> text element nested inside a <mensaje> entry
+    if (mensajeElement.parentNode?.nodeName === 'mensaje') {
+      continue;
+    }
+
+    const identificador = mensajeElement.getElementsByTagName('identificador')[0]?.textContent || '';
+    const mensaje = mensajeElement.getElementsByTagName('mensaje')[0]?.textContent || '';
+    const tipo = mensajeElement.getElementsByTagName('tipo')[0]?.textContent || 'INFO';
+    const informacionAdicional = mensajeElement.getElementsByTagName('informacionAdicional')[0]?.textContent;
+
+    mensajes.push({
+      identificador,
+      mensaje,
+      tipo,
+      ...(informacionAdicional && { informacionAdicional }),
+    });
+  }
+
+  if (mensajes.length === 0) return undefined;
+
+  return mensajes.length === 1 ? { mensaje: mensajes[0] } : { mensaje: mensajes };
 }
-*/
+
+/**
+ * Parse the SRI authorization XML response into an AutorizacionSRI object
+ */
+function parseAutorizacionResponse(xmlString: string): AutorizacionSRI {
+  try {
+    const parser = new DOMParser();
+    const xmlDoc = parser.parseFromString(xmlString, 'text/xml');
+
+    const faultElements = xmlDoc.getElementsByTagName('soap:Fault');
+    if (faultElements.length > 0) {
+      const faultString =
+        faultElements[0].getElementsByTagName('faultstring')[0]?.textContent || 'Error SOAP desconocido';
+      return {
+        estado: 'ERROR_SOAP',
+        mensajes: {
+          mensaje: { identificador: '001', mensaje: `Error SOAP: ${faultString}`, tipo: 'ERROR' },
+        },
+      };
+    }
+
+    const autorizacionElement = xmlDoc.getElementsByTagName('autorizacion')[0];
+    if (!autorizacionElement) {
+      // The SRI may respond without an autorizacion node while the receipt is still in process
+      return { estado: 'EN PROCESO' };
+    }
+
+    const estado = autorizacionElement.getElementsByTagName('estado')[0]?.textContent || 'DESCONOCIDO';
+    const numeroAutorizacion = autorizacionElement.getElementsByTagName('numeroAutorizacion')[0]?.textContent;
+    const fechaAutorizacion = autorizacionElement.getElementsByTagName('fechaAutorizacion')[0]?.textContent;
+    const ambiente = autorizacionElement.getElementsByTagName('ambiente')[0]?.textContent;
+
+    return {
+      estado,
+      ...(numeroAutorizacion && { numeroAutorizacion }),
+      ...(fechaAutorizacion && { fechaAutorizacion }),
+      ...(ambiente && { ambiente }),
+      ...(extraerMensajes(autorizacionElement) && { mensajes: extraerMensajes(autorizacionElement) }),
+    };
+  } catch (error) {
+    return {
+      estado: 'ERROR_PARSING',
+      mensajes: {
+        mensaje: {
+          identificador: '001',
+          mensaje: 'Error al procesar respuesta de autorización del SRI',
+          tipo: 'ERROR',
+        },
+      },
+    };
+  }
+}
+
+/**
+ * Queries the SRI authorization web service for a receipt by its access key.
+ * In the offline scheme the authorization number equals the access key.
+ * @param claveAcceso 49-digit access key of the receipt.
+ * @returns Promise<AutorizacionSRI> The parsed authorization response.
+ */
+export async function autorizarComprobanteSRI(claveAcceso: string): Promise<AutorizacionSRI> {
+  try {
+    const soapRequestBody =
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+      '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ec="http://ec.gob.sri.ws.autorizacion">' +
+      '<soap:Header/>' +
+      '<soap:Body>' +
+      '<ec:autorizacionComprobante>' +
+      '<claveAccesoComprobante>' +
+      claveAcceso +
+      '</claveAccesoComprobante>' +
+      '</ec:autorizacionComprobante>' +
+      '</soap:Body>' +
+      '</soap:Envelope>';
+
+    const possibleActions = [
+      '"http://ec.gob.sri.ws.autorizacion/autorizacionComprobante"',
+      '"autorizacionComprobante"',
+      '""',
+    ];
+
+    for (const soapAction of possibleActions) {
+      try {
+        const headers: Record<string, string> = {
+          'Content-Type': 'text/xml; charset=utf-8',
+        };
+
+        if (soapAction && soapAction !== '""') {
+          headers['SOAPAction'] = soapAction;
+        }
+
+        const response = await axios.post(getAutorizacionWsdlUrl(), soapRequestBody, {
+          headers,
+          timeout: 30000,
+        });
+
+        if (typeof response.data === 'string') {
+          const result = parseAutorizacionResponse(response.data);
+          if (result.estado !== 'ERROR_SOAP') {
+            return result;
+          }
+        }
+      } catch (error: any) {
+        continue;
+      }
+    }
+
+    return {
+      estado: 'ERROR_COMUNICACION',
+      mensajes: {
+        mensaje: {
+          identificador: '000',
+          mensaje: 'No se pudo determinar el SOAPAction correcto para el servicio de autorización del SRI',
+          tipo: 'ERROR',
+        },
+      },
+    };
+  } catch (error: any) {
+    return {
+      estado: 'ERROR_COMUNICACION',
+      mensajes: {
+        mensaje: {
+          identificador: '000',
+          mensaje: `Error de comunicación con SRI: ${error.message}`,
+          tipo: 'ERROR',
+        },
+      },
+    };
+  }
+}

--- a/src/utils/xml.utils.ts
+++ b/src/utils/xml.utils.ts
@@ -4,6 +4,7 @@ import { IClient } from '../models/Client';
 import { IProduct } from '../models/Product';
 import { InvoiceRequest } from '../interfaces/invoice.interface';
 import { CreditNoteRequest } from '../interfaces/credit-note.interface';
+import { DebitNoteRequest } from '../interfaces/debit-note.interface';
 
 /**
  * IVA configuration (tabla 17 de la Ficha Técnica del SRI).
@@ -363,6 +364,165 @@ export function generarXMLNotaCredito(
 
   doc
     .up() // salir de <detalles>
+    .ele('infoAdicional')
+    .ele('campoAdicional', { nombre: 'Email' })
+    .txt(cliente.email || 'sinfactura@cliente.com')
+    .up()
+    .ele('campoAdicional', { nombre: 'Teléfono' })
+    .txt(cliente.telefono || '0000000000')
+    .up();
+
+  return doc.end({ prettyPrint: true });
+}
+
+/**
+ * Genera un documento XML para una nota de débito electrónica según el formato
+ * v1.0.0 de la Ficha Técnica del SRI de Ecuador (codDoc 05)
+ * @param notaDebito Datos de la nota de débito
+ * @param empresa Empresa emisora
+ * @param cliente Cliente
+ * @param claveAcceso Clave de acceso generada
+ * @param secuencial Número secuencial de la nota de débito
+ * @returns XML de la nota de débito como string
+ */
+export function generarXMLNotaDebito(
+  notaDebito: DebitNoteRequest,
+  empresa: IIssuingCompany,
+  cliente: IClient,
+  claveAcceso: string,
+  secuencial: string,
+): string {
+  const info = notaDebito.infoNotaDebito;
+
+  const doc = create({ version: '1.0', encoding: 'UTF-8' })
+    .ele('notaDebito', {
+      id: 'comprobante',
+      version: '1.0.0',
+    })
+    .ele('infoTributaria')
+    .ele('ambiente')
+    .txt(String(empresa.tipo_ambiente))
+    .up()
+    .ele('tipoEmision')
+    .txt(String(empresa.tipo_emision))
+    .up()
+    .ele('razonSocial')
+    .txt(empresa.razon_social)
+    .up()
+    .ele('nombreComercial')
+    .txt(empresa.nombre_comercial)
+    .up()
+    .ele('ruc')
+    .txt(empresa.ruc)
+    .up()
+    .ele('claveAcceso')
+    .txt(claveAcceso)
+    .up()
+    .ele('codDoc')
+    .txt('05')
+    .up() // nota de débito
+    .ele('estab')
+    .txt(empresa.codigo_establecimiento)
+    .up()
+    .ele('ptoEmi')
+    .txt(empresa.punto_emision)
+    .up()
+    .ele('secuencial')
+    .txt(secuencial)
+    .up()
+    .ele('dirMatriz')
+    .txt(empresa.direccion_matriz || empresa.direccion || 'Dirección no especificada')
+    .up()
+    .up()
+    .ele('infoNotaDebito')
+    .ele('fechaEmision')
+    .txt(info.fechaEmision)
+    .up()
+    .ele('dirEstablecimiento')
+    .txt(empresa.direccion_establecimiento || empresa.direccion || 'Dirección no especificada')
+    .up()
+    .ele('tipoIdentificacionComprador')
+    .txt(info.tipoIdentificacionComprador)
+    .up()
+    .ele('razonSocialComprador')
+    .txt(cliente.razon_social)
+    .up()
+    .ele('identificacionComprador')
+    .txt(cliente.identificacion)
+    .up()
+    .ele('obligadoContabilidad')
+    .txt(empresa.obligado_contabilidad ? 'SI' : 'NO')
+    .up()
+    .ele('codDocModificado')
+    .txt(info.codDocModificado)
+    .up()
+    .ele('numDocModificado')
+    .txt(info.numDocModificado)
+    .up()
+    .ele('fechaEmisionDocSustento')
+    .txt(info.fechaEmisionDocSustento)
+    .up()
+    .ele('totalSinImpuestos')
+    .txt(info.totalSinImpuestos)
+    .up()
+    .ele('impuestos');
+
+  // Tax codes are taken from the request (tablas 16 y 17 de la ficha técnica).
+  // La tarifa de IVA corresponde a la fecha de emisión del documento de sustento.
+  for (const item of info.impuestos) {
+    const impuesto = item.impuesto;
+    doc
+      .ele('impuesto')
+      .ele('codigo')
+      .txt(impuesto.codigo)
+      .up()
+      .ele('codigoPorcentaje')
+      .txt(impuesto.codigoPorcentaje)
+      .up()
+      .ele('tarifa')
+      .txt(impuesto.tarifa)
+      .up()
+      .ele('baseImponible')
+      .txt(impuesto.baseImponible)
+      .up()
+      .ele('valor')
+      .txt(impuesto.valor)
+      .up()
+      .up();
+  }
+
+  // Cursor tracking: xmlbuilder2 returns a new node reference on each call,
+  // so the position after each block must be captured explicitly
+  const pagosNode = doc
+    .up() // salir de <impuestos>
+    .ele('valorTotal')
+    .txt(info.valorTotal)
+    .up()
+    .ele('pagos');
+
+  for (const item of info.pagos) {
+    const pago = item.pago;
+    const pagoNode = pagosNode.ele('pago').ele('formaPago').txt(pago.formaPago).up().ele('total').txt(pago.total).up();
+
+    if (pago.plazo) {
+      pagoNode.ele('plazo').txt(pago.plazo).up();
+    }
+    if (pago.unidadTiempo) {
+      pagoNode.ele('unidadTiempo').txt(pago.unidadTiempo).up();
+    }
+  }
+
+  const motivosNode = pagosNode
+    .up() // salir de <pagos>
+    .up() // salir de <infoNotaDebito>
+    .ele('motivos');
+
+  for (const item of notaDebito.motivos) {
+    motivosNode.ele('motivo').ele('razon').txt(item.motivo.razon).up().ele('valor').txt(item.motivo.valor).up().up();
+  }
+
+  motivosNode
+    .up() // salir de <motivos>
     .ele('infoAdicional')
     .ele('campoAdicional', { nombre: 'Email' })
     .txt(cliente.email || 'sinfactura@cliente.com')

--- a/src/utils/xml.utils.ts
+++ b/src/utils/xml.utils.ts
@@ -3,6 +3,18 @@ import { IIssuingCompany } from '../models/IssuingCompany';
 import { IClient } from '../models/Client';
 import { IProduct } from '../models/Product';
 import { InvoiceRequest } from '../interfaces/invoice.interface';
+import { CreditNoteRequest } from '../interfaces/credit-note.interface';
+
+/**
+ * IVA configuration (tabla 17 de la Ficha Técnica del SRI).
+ * Defaults to the 15% rate in force since April 2024 (codigoPorcentaje 4).
+ */
+export function obtenerConfiguracionIVA(): { tarifa: string; codigoPorcentaje: string } {
+  return {
+    tarifa: process.env.IVA || '15',
+    codigoPorcentaje: process.env.CODIGO_PORCENTAJE || '4',
+  };
+}
 
 /**
  * Genera un documento XML para una factura electrónica según el formato del SRI de Ecuador
@@ -22,6 +34,7 @@ export function generarXMLFactura(
   claveAcceso: string,
   secuencial: string,
 ): string {
+  const iva = obtenerConfiguracionIVA();
   const doc = create({ version: '1.0', encoding: 'UTF-8' })
     .ele('factura', {
       id: 'comprobante',
@@ -93,13 +106,17 @@ export function generarXMLFactura(
     .txt('2')
     .up()
     .ele('codigoPorcentaje')
-    .txt('2')
+    .txt(iva.codigoPorcentaje)
     .up()
     .ele('baseImponible')
     .txt(factura.infoFactura.totalSinImpuestos)
     .up()
     .ele('valor')
-    .txt(productos.reduce((acc, p) => (p.tiene_iva ? acc + 0.12 * p.precio_unitario : acc), 0).toFixed(2))
+    .txt(
+      productos
+        .reduce((acc, p) => (p.tiene_iva ? acc + (parseFloat(iva.tarifa) / 100) * p.precio_unitario : acc), 0)
+        .toFixed(2),
+    )
     .up()
     .up()
     .up()
@@ -144,16 +161,200 @@ export function generarXMLFactura(
       .txt('2')
       .up()
       .ele('codigoPorcentaje')
-      .txt('2')
+      .txt(iva.codigoPorcentaje)
       .up()
       .ele('tarifa')
-      .txt('12.00')
+      .txt(`${iva.tarifa}.00`)
       .up()
       .ele('baseImponible')
       .txt(d.precioTotalSinImpuesto)
       .up()
       .ele('valor')
       .txt(d.impuestos[0].impuesto.valor)
+      .up()
+      .up()
+      .up()
+      .up();
+  }
+
+  doc
+    .up() // salir de <detalles>
+    .ele('infoAdicional')
+    .ele('campoAdicional', { nombre: 'Email' })
+    .txt(cliente.email || 'sinfactura@cliente.com')
+    .up()
+    .ele('campoAdicional', { nombre: 'Teléfono' })
+    .txt(cliente.telefono || '0000000000')
+    .up();
+
+  return doc.end({ prettyPrint: true });
+}
+
+/**
+ * Genera un documento XML para una nota de crédito electrónica según el formato
+ * v1.1.0 de la Ficha Técnica del SRI de Ecuador (codDoc 04)
+ * @param notaCredito Datos de la nota de crédito
+ * @param empresa Empresa emisora
+ * @param cliente Cliente
+ * @param claveAcceso Clave de acceso generada
+ * @param secuencial Número secuencial de la nota de crédito
+ * @returns XML de la nota de crédito como string
+ */
+export function generarXMLNotaCredito(
+  notaCredito: CreditNoteRequest,
+  empresa: IIssuingCompany,
+  cliente: IClient,
+  claveAcceso: string,
+  secuencial: string,
+): string {
+  const info = notaCredito.infoNotaCredito;
+  const totalIva = notaCredito.detalles
+    .reduce((acc, d) => acc + parseFloat(d.detalle.impuestos[0].impuesto.valor), 0)
+    .toFixed(2);
+  // Tax codes are taken from the request details (tablas 16 y 17 de la ficha técnica)
+  const impuestoReferencia = notaCredito.detalles[0].detalle.impuestos[0].impuesto;
+
+  const doc = create({ version: '1.0', encoding: 'UTF-8' })
+    .ele('notaCredito', {
+      id: 'comprobante',
+      version: '1.1.0',
+    })
+    .ele('infoTributaria')
+    .ele('ambiente')
+    .txt(String(empresa.tipo_ambiente))
+    .up()
+    .ele('tipoEmision')
+    .txt(String(empresa.tipo_emision))
+    .up()
+    .ele('razonSocial')
+    .txt(empresa.razon_social)
+    .up()
+    .ele('nombreComercial')
+    .txt(empresa.nombre_comercial)
+    .up()
+    .ele('ruc')
+    .txt(empresa.ruc)
+    .up()
+    .ele('claveAcceso')
+    .txt(claveAcceso)
+    .up()
+    .ele('codDoc')
+    .txt('04')
+    .up() // nota de crédito
+    .ele('estab')
+    .txt(empresa.codigo_establecimiento)
+    .up()
+    .ele('ptoEmi')
+    .txt(empresa.punto_emision)
+    .up()
+    .ele('secuencial')
+    .txt(secuencial)
+    .up()
+    .ele('dirMatriz')
+    .txt(empresa.direccion_matriz || empresa.direccion || 'Dirección no especificada')
+    .up()
+    .up()
+    .ele('infoNotaCredito')
+    .ele('fechaEmision')
+    .txt(info.fechaEmision)
+    .up()
+    .ele('dirEstablecimiento')
+    .txt(empresa.direccion_establecimiento || empresa.direccion || 'Dirección no especificada')
+    .up()
+    .ele('tipoIdentificacionComprador')
+    .txt(info.tipoIdentificacionComprador)
+    .up()
+    .ele('razonSocialComprador')
+    .txt(cliente.razon_social)
+    .up()
+    .ele('identificacionComprador')
+    .txt(cliente.identificacion)
+    .up()
+    .ele('obligadoContabilidad')
+    .txt(empresa.obligado_contabilidad ? 'SI' : 'NO')
+    .up()
+    .ele('codDocModificado')
+    .txt(info.codDocModificado)
+    .up()
+    .ele('numDocModificado')
+    .txt(info.numDocModificado)
+    .up()
+    .ele('fechaEmisionDocSustento')
+    .txt(info.fechaEmisionDocSustento)
+    .up()
+    .ele('totalSinImpuestos')
+    .txt(info.totalSinImpuestos)
+    .up()
+    .ele('valorModificacion')
+    .txt(info.valorModificacion)
+    .up()
+    .ele('moneda')
+    .txt(info.moneda || 'DOLAR')
+    .up()
+    .ele('totalConImpuestos')
+    .ele('totalImpuesto')
+    .ele('codigo')
+    .txt(impuestoReferencia.codigo)
+    .up()
+    .ele('codigoPorcentaje')
+    .txt(impuestoReferencia.codigoPorcentaje)
+    .up()
+    .ele('baseImponible')
+    .txt(info.totalSinImpuestos)
+    .up()
+    .ele('valor')
+    .txt(totalIva)
+    .up()
+    .up()
+    .up()
+    .ele('motivo')
+    .txt(info.motivo)
+    .up()
+    .up()
+    .ele('detalles');
+
+  // Add credit note details
+  for (const item of notaCredito.detalles) {
+    const d = item.detalle;
+    const impuesto = d.impuestos[0].impuesto;
+    const detalle = doc.ele('detalle').ele('codigoInterno').txt(d.codigoInterno).up();
+
+    if (d.codigoAdicional) {
+      detalle.ele('codigoAdicional').txt(d.codigoAdicional).up();
+    }
+
+    detalle
+      .ele('descripcion')
+      .txt(d.descripcion)
+      .up()
+      .ele('cantidad')
+      .txt(d.cantidad)
+      .up()
+      .ele('precioUnitario')
+      .txt(d.precioUnitario)
+      .up()
+      .ele('descuento')
+      .txt(d.descuento || '0.00')
+      .up()
+      .ele('precioTotalSinImpuesto')
+      .txt(d.precioTotalSinImpuesto)
+      .up()
+      .ele('impuestos')
+      .ele('impuesto')
+      .ele('codigo')
+      .txt(impuesto.codigo)
+      .up()
+      .ele('codigoPorcentaje')
+      .txt(impuesto.codigoPorcentaje)
+      .up()
+      .ele('tarifa')
+      .txt(impuesto.tarifa)
+      .up()
+      .ele('baseImponible')
+      .txt(impuesto.baseImponible)
+      .up()
+      .ele('valor')
+      .txt(impuesto.valor)
       .up()
       .up()
       .up()


### PR DESCRIPTION
## Descripción

Implementa la emisión completa de **Notas de Débito electrónicas** (codDoc `05`, formato XML v1.0.0 de la Ficha Técnica v2.32 del SRI), continuando la serie de comprobantes iniciada con la nota de crédito.

Resuelve #22.

> ⚠️ **Depende de #21** — este PR está apilado sobre `feature/nota-de-credito` porque reutiliza la base de firma XAdES-BES y autorización introducida allí. Los dos primeros commits del diff pertenecen a #21; el commit propio de este PR es solo `feat(debit-note)`. Una vez mergeado #21, lo rebaso sobre main.

### Contenido

- **Modelos** `DebitNote` y `DebitNotePDF`, con referencia opcional a la factura modificada y los motivos (recargos) embebidos.
- **Generador XML** `generarXMLNotaDebito` con `infoNotaDebito` (`codDocModificado`, `numDocModificado`, `fechaEmisionDocSustento`, bloque `<impuestos>`, `valorTotal`, `<pagos>` con `formaPago` de la tabla 24) y el bloque `<motivos>` con pares `razon`/`valor`. A diferencia de factura y nota de crédito, este documento no lleva `<detalles>` de productos. Los códigos de impuesto se toman del request — según la ficha, la tarifa de IVA corresponde a la fecha de emisión del documento de sustento.
- **`DebitNoteService`** con el mismo flujo automático: clave de acceso (tipo `05`) → firma XAdES-BES (`signDebitNoteXml`) → recepción → consulta de autorización con reintentos → RIDE PDF (los motivos se representan como líneas del documento).
- **Endpoints** `POST /api/v1/debit-note/complete`, CRUD y `GET /:id/pdf`, con documentación **Swagger/OpenAPI** completa (schemas de pagos y motivos incluidos).
- **Tests**: 18 nuevos (XML con y sin `plazo`/`unidadTiempo`, clave de acceso módulo 11 tipo 05, rutas con Supertest). Suite completa: **97 tests** en verde, `npm run validate` pasa.

### Cómo probar

1. `POST /api/v1/debit-note/complete` con el body de ejemplo del Swagger (`/docs`), p. ej. un interés por mora sobre una factura autorizada.
2. Verificar en logs: `RECIBIDA` → `AUTORIZADO`, y el PDF en `GET /api/v1/debit-note/:id/pdf`.

### Roadmap

Serie de comprobantes SRI: 04 ✅ (#21), **05 (este PR)**, siguen guía de remisión (06) y comprobante de retención ATS 2.0.0 (07).
