### PR TITLE
feat: Comprobante de Retención electrónico ATS 2.0.0 (codDoc 07)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,10 +80,21 @@ EMAIL_PASSWORD=tu_contraseña_o_app_password
 SRI_ENVIRONMENT=1
 
 # URL de recepción del SRI - Ambiente de Pruebas
-SRI_RECEPCION_URL_PRUEBAS=https://celinium.sri.gob.ec/comprobantes-electronicos-ws/RecepcionComprobantesOffline?wsdl
+SRI_RECEPCION_URL_PRUEBAS=https://celcer.sri.gob.ec/comprobantes-electronicos-ws/RecepcionComprobantesOffline?wsdl
 
 # URL de recepción del SRI - Ambiente de Producción
 SRI_RECEPCION_URL_PRODUCCION=https://cel.sri.gob.ec/comprobantes-electronicos-ws/RecepcionComprobantesOffline?wsdl
+
+# URL de autorización del SRI - Ambiente de Pruebas
+SRI_AUTORIZACION_URL_PRUEBAS=https://celcer.sri.gob.ec/comprobantes-electronicos-ws/AutorizacionComprobantesOffline?wsdl
+
+# URL de autorización del SRI - Ambiente de Producción
+SRI_AUTORIZACION_URL_PRODUCCION=https://cel.sri.gob.ec/comprobantes-electronicos-ws/AutorizacionComprobantesOffline?wsdl
+
+# Tarifa de IVA vigente (sin signo de porcentaje) y su código según la tabla 17 del SRI
+# 15% -> codigoPorcentaje 4 (vigente desde abril 2024)
+IVA=15
+CODIGO_PORCENTAJE=4
 
 # =================================
 # ALMACENAMIENTO DE PDFs

--- a/.env.example
+++ b/.env.example
@@ -23,11 +23,14 @@ MONGO_URI=mongodb://localhost:27017/f-sri
 
 # Secreto para firmar tokens JWT (genera una cadena aleatoria segura)
 # Puedes usar: node -e "console.log(require('crypto').randomBytes(64).toString('hex'))"
+# Otro medio para generarlo puede ser "openssl rand -hex 64"
 JWT_SECRET=tu_secreto_jwt_muy_seguro_aqui
 
-# Clave de encriptación de 32 caracteres para datos sensibles
+# Clave de encriptación de 32 bytes (64 caracteres hexadecimales) para datos sensibles
 # Puedes usar: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
-ENCRYPTION_KEY=tu_clave_de_encriptacion_de_32_caracteres
+# ".toString('hex')" incrementa la longitud del string de resultado al doble del numero de bytes
+# Otro medio para generarlo puede ser "openssl rand -hex 32"
+ENCRYPTION_KEY=1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcd
 
 # =================================
 # REGISTRO DE USUARIOS

--- a/__tests__/creditNote.routes.test.ts
+++ b/__tests__/creditNote.routes.test.ts
@@ -1,0 +1,194 @@
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { createApp } from '../src/testApp';
+
+// --- Model mocks ---
+const creditNoteInstanceMocks = {
+  save: jest.fn().mockResolvedValue({}),
+};
+
+const creditNoteStaticMocks = {
+  find: jest.fn().mockResolvedValue([]),
+  findById: jest.fn().mockResolvedValue(null),
+  findOne: jest.fn().mockResolvedValue(null),
+  findByIdAndUpdate: jest.fn().mockResolvedValue(null),
+  findByIdAndDelete: jest.fn().mockResolvedValue(null),
+};
+
+jest.mock('../src/models/CreditNote', () => {
+  class MockCreditNote {
+    constructor(public data: any) {}
+    save = creditNoteInstanceMocks.save;
+    static find = (...args: any[]) => creditNoteStaticMocks.find(...args);
+    static findById = (...args: any[]) => creditNoteStaticMocks.findById(...args);
+    static findOne = (...args: any[]) => creditNoteStaticMocks.findOne(...args);
+    static findByIdAndUpdate = (...args: any[]) => creditNoteStaticMocks.findByIdAndUpdate(...args);
+    static findByIdAndDelete = (...args: any[]) => creditNoteStaticMocks.findByIdAndDelete(...args);
+  }
+  return { __esModule: true, default: MockCreditNote };
+});
+
+const creditNotePDFStaticMocks = {
+  findOne: jest.fn().mockResolvedValue(null),
+};
+
+jest.mock('../src/models/CreditNotePDF', () => ({
+  __esModule: true,
+  default: {
+    findOne: (...args: any[]) => creditNotePDFStaticMocks.findOne(...args),
+  },
+}));
+
+// --- Service mock ---
+const crearNotaCreditoCompletaMock = jest.fn();
+jest.mock('../src/services/credit-note.service', () => ({
+  CreditNoteService: {
+    crearNotaCreditoCompleta: (...args: any[]) => crearNotaCreditoCompletaMock(...args),
+  },
+}));
+
+const app = createApp();
+const token = jwt.sign({ userId: '1' }, process.env.JWT_SECRET as string);
+const authHeader = `Bearer ${token}`;
+
+const notaCreditoPayload = {
+  infoTributaria: { ruc: '1790012345001' },
+  infoNotaCredito: {
+    fechaEmision: '17/05/2025',
+    tipoIdentificacionComprador: '05',
+    identificacionComprador: '0106079783',
+    codDocModificado: '01',
+    numDocModificado: '001-001-000000123',
+    fechaEmisionDocSustento: '10/05/2025',
+    totalSinImpuestos: '100.00',
+    valorModificacion: '115.00',
+    motivo: 'DEVOLUCIÓN',
+  },
+  detalles: [],
+};
+
+describe('Credit note routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /api/v1/credit-note/complete', () => {
+    it('requires authentication', async () => {
+      const res = await request(app).post('/api/v1/credit-note/complete').send({});
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 400 when nota_credito is missing', async () => {
+      const res = await request(app).post('/api/v1/credit-note/complete').set('Authorization', authHeader).send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(crearNotaCreditoCompletaMock).not.toHaveBeenCalled();
+    });
+
+    it('creates a complete credit note and returns its XML', async () => {
+      const resultadoMock = {
+        nota_credito: { secuencial: '000000001', clave_acceso: '123' },
+        detalles: [],
+        xml: '<notaCredito/>',
+        xml_firmado: null,
+        respuesta_sri: null,
+      };
+      crearNotaCreditoCompletaMock.mockResolvedValueOnce(resultadoMock);
+
+      const res = await request(app)
+        .post('/api/v1/credit-note/complete')
+        .set('Authorization', authHeader)
+        .send({ nota_credito: notaCreditoPayload });
+
+      expect(res.status).toBe(201);
+      expect(res.body.success).toBe(true);
+      expect(res.body.xml).toBe('<notaCredito/>');
+      expect(crearNotaCreditoCompletaMock).toHaveBeenCalledWith(notaCreditoPayload);
+    });
+
+    it('returns 400 for validation errors from the service', async () => {
+      crearNotaCreditoCompletaMock.mockRejectedValueOnce(new Error('Client not found'));
+
+      const res = await request(app)
+        .post('/api/v1/credit-note/complete')
+        .set('Authorization', authHeader)
+        .send({ nota_credito: notaCreditoPayload });
+
+      expect(res.status).toBe(400);
+      expect(res.body.message).toContain('Client not found');
+    });
+
+    it('returns 500 for unexpected service errors', async () => {
+      crearNotaCreditoCompletaMock.mockRejectedValueOnce(new Error('mongo down'));
+
+      const res = await request(app)
+        .post('/api/v1/credit-note/complete')
+        .set('Authorization', authHeader)
+        .send({ nota_credito: notaCreditoPayload });
+
+      expect(res.status).toBe(500);
+      expect(res.body.success).toBe(false);
+    });
+  });
+
+  describe('CRUD endpoints', () => {
+    it('lists credit notes', async () => {
+      creditNoteStaticMocks.find.mockResolvedValueOnce([{ secuencial: '000000001' }]);
+
+      const res = await request(app).get('/api/v1/credit-note').set('Authorization', authHeader);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+    });
+
+    it('returns 404 for a missing credit note', async () => {
+      const res = await request(app)
+        .get('/api/v1/credit-note/507f1f77bcf86cd799439011')
+        .set('Authorization', authHeader);
+
+      expect(res.status).toBe(404);
+    });
+
+    it('returns a credit note by id', async () => {
+      creditNoteStaticMocks.findById.mockResolvedValueOnce({ secuencial: '000000001' });
+
+      const res = await request(app)
+        .get('/api/v1/credit-note/507f1f77bcf86cd799439011')
+        .set('Authorization', authHeader);
+
+      expect(res.status).toBe(200);
+      expect(res.body.secuencial).toBe('000000001');
+    });
+
+    it('returns the PDF info of a credit note', async () => {
+      creditNotePDFStaticMocks.findOne.mockResolvedValueOnce({ pdf_url: 'https://cdn/pdf.pdf', estado: 'GENERADO' });
+
+      const res = await request(app)
+        .get('/api/v1/credit-note/507f1f77bcf86cd799439011/pdf')
+        .set('Authorization', authHeader);
+
+      expect(res.status).toBe(200);
+      expect(res.body.pdf_url).toBe('https://cdn/pdf.pdf');
+    });
+
+    it('returns 404 when the credit note has no PDF yet', async () => {
+      const res = await request(app)
+        .get('/api/v1/credit-note/507f1f77bcf86cd799439011/pdf')
+        .set('Authorization', authHeader);
+
+      expect(res.status).toBe(404);
+    });
+
+    it('deletes a credit note', async () => {
+      creditNoteStaticMocks.findByIdAndDelete.mockResolvedValueOnce({ _id: '507f1f77bcf86cd799439011' });
+
+      const res = await request(app)
+        .delete('/api/v1/credit-note/507f1f77bcf86cd799439011')
+        .set('Authorization', authHeader);
+
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Deleted');
+    });
+  });
+});

--- a/__tests__/crud.routes.test.ts
+++ b/__tests__/crud.routes.test.ts
@@ -1,0 +1,649 @@
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+
+// --- Generic model mock factory ---
+function createModelMock(saved: any[]) {
+  const statics = {
+    find: jest.fn().mockResolvedValue([]),
+    findOne: jest.fn().mockResolvedValue(null),
+    findById: jest.fn().mockResolvedValue(null),
+    findByIdAndUpdate: jest.fn().mockResolvedValue(null),
+    findByIdAndDelete: jest.fn().mockResolvedValue(null),
+    countDocuments: jest.fn().mockResolvedValue(1),
+    saveMock: jest.fn().mockResolvedValue(undefined),
+  };
+  class MockModel {
+    [key: string]: any;
+    constructor(data: any) {
+      Object.assign(this, data);
+      this._id = 'doc-1';
+      saved.push(this);
+    }
+    save = () => statics.saveMock(this);
+    static find = (...args: any[]) => statics.find(...args);
+    static findOne = (...args: any[]) => statics.findOne(...args);
+    static findById = (...args: any[]) => statics.findById(...args);
+    static findByIdAndUpdate = (...args: any[]) => statics.findByIdAndUpdate(...args);
+    static findByIdAndDelete = (...args: any[]) => statics.findByIdAndDelete(...args);
+    static countDocuments = (...args: any[]) => statics.countDocuments(...args);
+  }
+  return { MockModel, statics };
+}
+
+const saved: any[] = [];
+const identificationTypeMock = createModelMock(saved);
+const clientMock = createModelMock(saved);
+const productMock = createModelMock(saved);
+const invoiceDetailMock = createModelMock(saved);
+const issuingCompanyMock = createModelMock(saved);
+const invoiceMock = createModelMock(saved);
+const invoicePDFMock = createModelMock(saved);
+const creditNoteMock = createModelMock(saved);
+const debitNoteMock = createModelMock(saved);
+const deliveryNoteMock = createModelMock(saved);
+const withholdingMock = createModelMock(saved);
+const userMock = createModelMock(saved);
+
+jest.mock('../src/models/IdentificationType', () => ({ __esModule: true, default: identificationTypeMock.MockModel }));
+jest.mock('../src/models/Client', () => ({ __esModule: true, default: clientMock.MockModel }));
+jest.mock('../src/models/Product', () => ({ __esModule: true, default: productMock.MockModel }));
+jest.mock('../src/models/InvoiceDetail', () => ({ __esModule: true, default: invoiceDetailMock.MockModel }));
+jest.mock('../src/models/IssuingCompany', () => ({ __esModule: true, default: issuingCompanyMock.MockModel }));
+jest.mock('../src/models/Invoice', () => ({ __esModule: true, default: invoiceMock.MockModel }));
+jest.mock('../src/models/InvoicePDF', () => ({ __esModule: true, default: invoicePDFMock.MockModel }));
+jest.mock('../src/models/CreditNote', () => ({ __esModule: true, default: creditNoteMock.MockModel }));
+jest.mock('../src/models/DebitNote', () => ({ __esModule: true, default: debitNoteMock.MockModel }));
+jest.mock('../src/models/DeliveryNote', () => ({ __esModule: true, default: deliveryNoteMock.MockModel }));
+jest.mock('../src/models/Withholding', () => ({ __esModule: true, default: withholdingMock.MockModel }));
+jest.mock('../src/models/User', () => ({ __esModule: true, default: userMock.MockModel }));
+
+jest.mock('../src/models/CreditNotePDF', () => ({
+  __esModule: true,
+  default: { findOne: jest.fn().mockResolvedValue(null) },
+}));
+jest.mock('../src/models/DebitNotePDF', () => ({
+  __esModule: true,
+  default: { findOne: jest.fn().mockResolvedValue(null) },
+}));
+jest.mock('../src/models/DeliveryNotePDF', () => ({
+  __esModule: true,
+  default: { findOne: jest.fn().mockResolvedValue(null) },
+}));
+jest.mock('../src/models/WithholdingPDF', () => ({
+  __esModule: true,
+  default: { findOne: jest.fn().mockResolvedValue(null) },
+}));
+
+// Services are unit-tested separately
+jest.mock('../src/services/invoice.service', () => ({ InvoiceService: { crearFacturaCompleta: jest.fn() } }));
+jest.mock('../src/services/credit-note.service', () => ({
+  CreditNoteService: { crearNotaCreditoCompleta: jest.fn() },
+}));
+jest.mock('../src/services/debit-note.service', () => ({ DebitNoteService: { crearNotaDebitoCompleta: jest.fn() } }));
+jest.mock('../src/services/delivery-note.service', () => ({
+  DeliveryNoteService: { crearGuiaRemisionCompleta: jest.fn() },
+}));
+jest.mock('../src/services/withholding.service', () => ({ WithholdingService: { crearRetencionCompleta: jest.fn() } }));
+
+// Loaded after the mock definitions so the hoisted jest.mock factories
+// can reference the model mocks when the routes import them
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { createApp } = require('../src/testApp');
+
+const app = createApp();
+const token = jwt.sign({ userId: '1' }, process.env.JWT_SECRET as string);
+const authHeader = `Bearer ${token}`;
+const ID = '507f1f77bcf86cd799439011';
+
+describe('verifyToken middleware', () => {
+  it('rejects malformed tokens', async () => {
+    const res = await request(app).get('/api/v1/client').set('Authorization', 'Bearer token-invalido');
+    expect(res.status).toBe(401);
+    expect(res.body.message).toBe('Invalid token');
+  });
+});
+
+describe.each([
+  ['client', clientMock],
+  ['product', productMock],
+  ['invoice-detail', invoiceDetailMock],
+  ['identification-type', identificationTypeMock],
+])('CRUD /api/v1/%s', (ruta, mock) => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    saved.length = 0;
+  });
+
+  it('creates a document', async () => {
+    const res = await request(app).post(`/api/v1/${ruta}`).set('Authorization', authHeader).send({ campo: 'valor' });
+
+    expect(res.status).toBe(201);
+    expect(saved).toHaveLength(1);
+  });
+
+  it('lists documents', async () => {
+    mock.statics.find.mockResolvedValueOnce([{ _id: ID }]);
+
+    const res = await request(app).get(`/api/v1/${ruta}`).set('Authorization', authHeader);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+  });
+
+  it('returns 404 for a missing document and 200 when found', async () => {
+    let res = await request(app).get(`/api/v1/${ruta}/${ID}`).set('Authorization', authHeader);
+    expect(res.status).toBe(404);
+
+    mock.statics.findById.mockResolvedValueOnce({ _id: ID });
+    res = await request(app).get(`/api/v1/${ruta}/${ID}`).set('Authorization', authHeader);
+    expect(res.status).toBe(200);
+  });
+
+  it('updates and deletes documents', async () => {
+    mock.statics.findByIdAndUpdate.mockResolvedValueOnce({ _id: ID, actualizado: true });
+    let res = await request(app).put(`/api/v1/${ruta}/${ID}`).set('Authorization', authHeader).send({ a: 1 });
+    expect(res.status).toBe(200);
+
+    mock.statics.findByIdAndDelete.mockResolvedValueOnce({ _id: ID });
+    res = await request(app).delete(`/api/v1/${ruta}/${ID}`).set('Authorization', authHeader);
+    expect(res.status).toBe(200);
+
+    // 404 branches
+    res = await request(app).put(`/api/v1/${ruta}/${ID}`).set('Authorization', authHeader).send({});
+    expect(res.status).toBe(404);
+    res = await request(app).delete(`/api/v1/${ruta}/${ID}`).set('Authorization', authHeader);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 500 when the database fails', async () => {
+    mock.statics.find.mockRejectedValueOnce(new Error('mongo down'));
+
+    const res = await request(app).get(`/api/v1/${ruta}`).set('Authorization', authHeader);
+
+    expect(res.status).toBe(500);
+  });
+});
+
+describe.each([
+  ['credit-note', creditNoteMock],
+  ['debit-note', debitNoteMock],
+  ['delivery-note', deliveryNoteMock],
+  ['withholding', withholdingMock],
+  ['invoice', invoiceMock],
+])('Raw CRUD of /api/v1/%s', (ruta, mock) => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    saved.length = 0;
+  });
+
+  it('creates a raw document with POST /', async () => {
+    const res = await request(app).post(`/api/v1/${ruta}`).set('Authorization', authHeader).send({ campo: 'valor' });
+
+    expect(res.status).toBe(201);
+    expect(saved).toHaveLength(1);
+  });
+
+  it('updates a document with PUT /:id', async () => {
+    mock.statics.findByIdAndUpdate.mockResolvedValueOnce({ _id: ID });
+
+    const res = await request(app).put(`/api/v1/${ruta}/${ID}`).set('Authorization', authHeader).send({ a: 1 });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('gets a document by id and handles the 404 case', async () => {
+    mock.statics.findById.mockResolvedValueOnce({ _id: ID });
+    let res = await request(app).get(`/api/v1/${ruta}/${ID}`).set('Authorization', authHeader);
+    expect(res.status).toBe(200);
+
+    res = await request(app).get(`/api/v1/${ruta}/${ID}`).set('Authorization', authHeader);
+    expect(res.status).toBe(404);
+  });
+
+  it('deletes a document and handles the 404 case', async () => {
+    mock.statics.findByIdAndDelete.mockResolvedValueOnce({ _id: ID });
+    let res = await request(app).delete(`/api/v1/${ruta}/${ID}`).set('Authorization', authHeader);
+    expect(res.status).toBe(200);
+
+    res = await request(app).delete(`/api/v1/${ruta}/${ID}`).set('Authorization', authHeader);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 500 when the database fails on list', async () => {
+    mock.statics.find.mockRejectedValueOnce(new Error('mongo down'));
+
+    const res = await request(app).get(`/api/v1/${ruta}`).set('Authorization', authHeader);
+
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('IssuingCompany routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    saved.length = 0;
+  });
+
+  it('lists, gets, updates and deletes companies', async () => {
+    issuingCompanyMock.statics.find.mockResolvedValueOnce([{ _id: ID }]);
+    let res = await request(app).get('/api/v1/issuing-company').set('Authorization', authHeader);
+    expect(res.status).toBe(200);
+
+    issuingCompanyMock.statics.findById.mockResolvedValueOnce({ _id: ID });
+    res = await request(app).get(`/api/v1/issuing-company/${ID}`).set('Authorization', authHeader);
+    expect(res.status).toBe(200);
+
+    res = await request(app).get(`/api/v1/issuing-company/${ID}`).set('Authorization', authHeader);
+    expect(res.status).toBe(404);
+
+    issuingCompanyMock.statics.findByIdAndUpdate.mockResolvedValueOnce({ _id: ID });
+    res = await request(app).put(`/api/v1/issuing-company/${ID}`).set('Authorization', authHeader).send({ a: 1 });
+    expect(res.status).toBe(200);
+
+    issuingCompanyMock.statics.findByIdAndDelete.mockResolvedValueOnce({ _id: ID });
+    res = await request(app).delete(`/api/v1/issuing-company/${ID}`).set('Authorization', authHeader);
+    expect(res.status).toBe(200);
+  });
+
+  it('re-encrypts the certificate password and reads a certificate file on update', async () => {
+    const fs = require('fs');
+    jest.spyOn(fs, 'readFileSync').mockReturnValueOnce(Buffer.from('p12-bytes'));
+    issuingCompanyMock.statics.findByIdAndUpdate.mockResolvedValueOnce({ _id: ID });
+
+    const res = await request(app)
+      .put(`/api/v1/issuing-company/${ID}`)
+      .set('Authorization', authHeader)
+      .send({ certificatePath: '/tmp/cert.p12', certificate_password: 'test-new-cert-password', razon_social: 'X' });
+
+    expect(res.status).toBe(200);
+    const [, updateData] = issuingCompanyMock.statics.findByIdAndUpdate.mock.calls[0];
+    expect(updateData.certificate).toBe(Buffer.from('p12-bytes').toString('base64'));
+    expect(updateData.certificate_password).toBeDefined();
+    expect(updateData.certificate_password).not.toBe('test-new-cert-password'); // stored encrypted
+    jest.restoreAllMocks();
+  });
+
+  it('returns 404 when updating or deleting a missing company', async () => {
+    let res = await request(app).put(`/api/v1/issuing-company/${ID}`).set('Authorization', authHeader).send({ a: 1 });
+    expect(res.status).toBe(404);
+
+    res = await request(app).delete(`/api/v1/issuing-company/${ID}`).set('Authorization', authHeader);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 500 on database failures for every endpoint', async () => {
+    issuingCompanyMock.statics.find.mockRejectedValueOnce(new Error('mongo down'));
+    let res = await request(app).get('/api/v1/issuing-company').set('Authorization', authHeader);
+    expect(res.status).toBe(500);
+
+    issuingCompanyMock.statics.findById.mockRejectedValueOnce(new Error('mongo down'));
+    res = await request(app).get(`/api/v1/issuing-company/${ID}`).set('Authorization', authHeader);
+    expect(res.status).toBe(500);
+
+    issuingCompanyMock.statics.findByIdAndUpdate.mockRejectedValueOnce(new Error('mongo down'));
+    res = await request(app).put(`/api/v1/issuing-company/${ID}`).set('Authorization', authHeader).send({ a: 1 });
+    expect(res.status).toBe(500);
+
+    issuingCompanyMock.statics.findByIdAndDelete.mockRejectedValueOnce(new Error('mongo down'));
+    res = await request(app).delete(`/api/v1/issuing-company/${ID}`).set('Authorization', authHeader);
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('Invoice route error branches', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    saved.length = 0;
+  });
+
+  it('returns 400 when factura is missing on /complete', async () => {
+    const res = await request(app).post('/api/v1/invoice/complete').set('Authorization', authHeader).send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  it('returns 500 when the complete-invoice service fails unexpectedly', async () => {
+    const { InvoiceService } = require('../src/services/invoice.service');
+    InvoiceService.crearFacturaCompleta.mockRejectedValueOnce(new Error('mongo down'));
+
+    const res = await request(app)
+      .post('/api/v1/invoice/complete')
+      .set('Authorization', authHeader)
+      .send({ factura: { infoTributaria: {} } });
+
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 400 for validation errors from the complete-invoice service', async () => {
+    const { InvoiceService } = require('../src/services/invoice.service');
+    InvoiceService.crearFacturaCompleta.mockRejectedValueOnce(new Error('Client not found'));
+
+    const res = await request(app)
+      .post('/api/v1/invoice/complete')
+      .set('Authorization', authHeader)
+      .send({ factura: { infoTributaria: {} } });
+
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain('Client not found');
+  });
+
+  it('returns 500 on database failures for every CRUD endpoint', async () => {
+    invoiceMock.statics.findById.mockRejectedValueOnce(new Error('mongo down'));
+    let res = await request(app).get(`/api/v1/invoice/${ID}`).set('Authorization', authHeader);
+    expect(res.status).toBe(500);
+
+    invoiceMock.statics.findByIdAndUpdate.mockRejectedValueOnce(new Error('mongo down'));
+    res = await request(app).put(`/api/v1/invoice/${ID}`).set('Authorization', authHeader).send({ a: 1 });
+    expect(res.status).toBe(500);
+
+    invoiceMock.statics.findByIdAndDelete.mockRejectedValueOnce(new Error('mongo down'));
+    res = await request(app).delete(`/api/v1/invoice/${ID}`).set('Authorization', authHeader);
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 500 when the raw POST save fails', async () => {
+    invoiceMock.statics.saveMock.mockRejectedValueOnce(new Error('mongo down'));
+
+    const res = await request(app).post('/api/v1/invoice').set('Authorization', authHeader).send({ campo: 'valor' });
+
+    expect(res.status).toBe(500);
+  });
+
+  it('gets and deletes invoices including the 404 branches', async () => {
+    invoiceMock.statics.findById.mockResolvedValueOnce({ _id: ID });
+    let res = await request(app).get(`/api/v1/invoice/${ID}`).set('Authorization', authHeader);
+    expect(res.status).toBe(200);
+
+    res = await request(app).get(`/api/v1/invoice/${ID}`).set('Authorization', authHeader);
+    expect(res.status).toBe(404);
+
+    invoiceMock.statics.findByIdAndDelete.mockResolvedValueOnce({ _id: ID });
+    res = await request(app).delete(`/api/v1/invoice/${ID}`).set('Authorization', authHeader);
+    expect(res.status).toBe(200);
+
+    res = await request(app).delete(`/api/v1/invoice/${ID}`).set('Authorization', authHeader);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('InvoicePDF routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    saved.length = 0;
+  });
+
+  const CLAVE = '1705202501179001234500110010010000000011234567810';
+
+  it('lists PDFs with populated invoices', async () => {
+    invoicePDFMock.statics.find.mockReturnValueOnce({ populate: jest.fn().mockResolvedValue([{ _id: ID }]) } as any);
+
+    const res = await request(app).get('/api/v1/invoice-pdf').set('Authorization', authHeader);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+  });
+
+  it('finds a PDF by invoice id and by access key', async () => {
+    invoicePDFMock.statics.findOne.mockResolvedValueOnce({ _id: ID });
+    let res = await request(app).get(`/api/v1/invoice-pdf/invoice/${ID}`).set('Authorization', authHeader);
+    expect(res.status).toBe(200);
+
+    res = await request(app).get(`/api/v1/invoice-pdf/invoice/${ID}`).set('Authorization', authHeader);
+    expect(res.status).toBe(404);
+
+    invoicePDFMock.statics.findOne.mockResolvedValueOnce({ _id: ID, claveAcceso: CLAVE });
+    res = await request(app).get(`/api/v1/invoice-pdf/access-key/${CLAVE}`).set('Authorization', authHeader);
+    expect(res.status).toBe(200);
+  });
+
+  it('redirects to the public PDF URL on download', async () => {
+    invoicePDFMock.statics.findOne.mockResolvedValueOnce({ pdf_url: 'https://cdn/f.pdf' });
+
+    const res = await request(app).get(`/api/v1/invoice-pdf/download/${CLAVE}`).set('Authorization', authHeader);
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('https://cdn/f.pdf');
+  });
+
+  it('returns 404 on download when the PDF has no URL', async () => {
+    invoicePDFMock.statics.findOne.mockResolvedValueOnce({ pdf_url: '' });
+
+    const res = await request(app).get(`/api/v1/invoice-pdf/download/${CLAVE}`).set('Authorization', authHeader);
+
+    expect(res.status).toBe(404);
+  });
+
+  it('queues an email send and reports email status', async () => {
+    const doc: any = { email_estado: 'NO_ENVIADO', save: jest.fn().mockResolvedValue({}) };
+    invoicePDFMock.statics.findOne.mockResolvedValueOnce(doc);
+    let res = await request(app)
+      .post(`/api/v1/invoice-pdf/send-email/${CLAVE}`)
+      .set('Authorization', authHeader)
+      .send({ email_destinatario: 'cliente@test.com' });
+    expect(res.status).toBe(200);
+    expect(doc.email_estado).toBe('PENDIENTE');
+
+    res = await request(app).post(`/api/v1/invoice-pdf/send-email/${CLAVE}`).set('Authorization', authHeader).send({});
+    expect(res.status).toBe(400);
+
+    invoicePDFMock.statics.findOne.mockResolvedValueOnce({ email_estado: 'PENDIENTE', email_intentos: 1 });
+    res = await request(app).get(`/api/v1/invoice-pdf/email-status/${CLAVE}`).set('Authorization', authHeader);
+    expect(res.status).toBe(200);
+    expect(res.body.email_estado).toBe('PENDIENTE');
+  });
+
+  it('handles email retries and the already-sent case', async () => {
+    const doc: any = { email_estado: 'ERROR', save: jest.fn().mockResolvedValue({}) };
+    invoicePDFMock.statics.findOne.mockResolvedValueOnce(doc);
+    let res = await request(app).post(`/api/v1/invoice-pdf/retry-email/${CLAVE}`).set('Authorization', authHeader);
+    expect(res.status).toBe(200);
+    expect(doc.email_estado).toBe('PENDIENTE');
+
+    invoicePDFMock.statics.findOne.mockResolvedValueOnce({ email_estado: 'ENVIADO' });
+    res = await request(app).post(`/api/v1/invoice-pdf/retry-email/${CLAVE}`).set('Authorization', authHeader);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 500 on database failures for every endpoint', async () => {
+    invoicePDFMock.statics.find.mockReturnValueOnce({
+      populate: jest.fn().mockRejectedValue(new Error('mongo down')),
+    } as any);
+    let res = await request(app).get('/api/v1/invoice-pdf').set('Authorization', authHeader);
+    expect(res.status).toBe(500);
+
+    invoicePDFMock.statics.findOne.mockRejectedValueOnce(new Error('mongo down'));
+    res = await request(app).get(`/api/v1/invoice-pdf/invoice/${ID}`).set('Authorization', authHeader);
+    expect(res.status).toBe(500);
+
+    invoicePDFMock.statics.findOne.mockRejectedValueOnce(new Error('mongo down'));
+    res = await request(app).get(`/api/v1/invoice-pdf/access-key/${CLAVE}`).set('Authorization', authHeader);
+    expect(res.status).toBe(500);
+
+    invoicePDFMock.statics.findOne.mockRejectedValueOnce(new Error('mongo down'));
+    res = await request(app).get(`/api/v1/invoice-pdf/download/${CLAVE}`).set('Authorization', authHeader);
+    expect(res.status).toBe(500);
+
+    invoicePDFMock.statics.findOne.mockRejectedValueOnce(new Error('mongo down'));
+    res = await request(app)
+      .post(`/api/v1/invoice-pdf/send-email/${CLAVE}`)
+      .set('Authorization', authHeader)
+      .send({ email_destinatario: 'cliente@test.com' });
+    expect(res.status).toBe(500);
+
+    invoicePDFMock.statics.findOne.mockRejectedValueOnce(new Error('mongo down'));
+    res = await request(app).get(`/api/v1/invoice-pdf/email-status/${CLAVE}`).set('Authorization', authHeader);
+    expect(res.status).toBe(500);
+
+    invoicePDFMock.statics.findOne.mockRejectedValueOnce(new Error('mongo down'));
+    res = await request(app).post(`/api/v1/invoice-pdf/retry-email/${CLAVE}`).set('Authorization', authHeader);
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 404 when the PDF does not exist on the secondary endpoints', async () => {
+    let res = await request(app).get(`/api/v1/invoice-pdf/access-key/${CLAVE}`).set('Authorization', authHeader);
+    expect(res.status).toBe(404);
+
+    res = await request(app).get(`/api/v1/invoice-pdf/download/${CLAVE}`).set('Authorization', authHeader);
+    expect(res.status).toBe(404);
+
+    res = await request(app)
+      .post(`/api/v1/invoice-pdf/send-email/${CLAVE}`)
+      .set('Authorization', authHeader)
+      .send({ email_destinatario: 'cliente@test.com' });
+    expect(res.status).toBe(404);
+
+    res = await request(app).get(`/api/v1/invoice-pdf/email-status/${CLAVE}`).set('Authorization', authHeader);
+    expect(res.status).toBe(404);
+
+    res = await request(app).post(`/api/v1/invoice-pdf/retry-email/${CLAVE}`).set('Authorization', authHeader);
+    expect(res.status).toBe(404);
+  });
+
+  it('acknowledges PDF regeneration requests', async () => {
+    const res = await request(app).post(`/api/v1/invoice-pdf/regenerate/${ID}`).set('Authorization', authHeader);
+
+    expect(res.status).toBe(200);
+    expect(res.body.facturaId).toBe(ID);
+  });
+});
+
+describe('Auth registration security', () => {
+  const originalEnv = { ...process.env };
+
+  const registroValido = {
+    email: 'nuevo@test.com',
+    password: 'test-user-password',
+    ruc: '1790012345001',
+    razon_social: 'NUEVA EMPRESA S.A.',
+    certificate: 'YmFzZTY0',
+    certificate_password: 'test-cert-password',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    saved.length = 0;
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('validates required fields and RUC format', async () => {
+    let res = await request(app).post('/register').send({});
+    expect(res.status).toBe(400);
+
+    res = await request(app).post('/register').send({ email: 'a@b.com', password: 'test-x' });
+    expect(res.status).toBe(400);
+
+    res = await request(app)
+      .post('/register')
+      .send({ ...registroValido, ruc: '123' });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain('RUC inválido');
+
+    res = await request(app)
+      .post('/register')
+      .send({ ...registroValido, certificate: undefined });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain('Certificado');
+
+    res = await request(app)
+      .post('/register')
+      .send({ ...registroValido, certificate_password: undefined });
+    expect(res.status).toBe(400);
+  });
+
+  it('requires the master key on first registration', async () => {
+    userMock.statics.countDocuments.mockResolvedValue(0);
+    issuingCompanyMock.statics.countDocuments.mockResolvedValue(0);
+    process.env.MASTER_REGISTRATION_KEY = 'llave-maestra';
+
+    let res = await request(app).post('/register').send(registroValido);
+    expect(res.status).toBe(403);
+    expect(res.body.message).toContain('maestra');
+
+    res = await request(app)
+      .post('/register')
+      .send({ ...registroValido, masterKey: 'llave-maestra' });
+    expect(res.status).toBe(201);
+    expect(res.body.token).toBeDefined();
+    expect(res.body.company.ruc).toBe(registroValido.ruc);
+  });
+
+  it('rejects registration when the system has no master key configured', async () => {
+    userMock.statics.countDocuments.mockResolvedValue(0);
+    issuingCompanyMock.statics.countDocuments.mockResolvedValue(0);
+    delete process.env.MASTER_REGISTRATION_KEY;
+
+    const res = await request(app).post('/register').send(registroValido);
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toContain('no configurado');
+  });
+
+  it('honors DISABLE_REGISTRATION for subsequent registrations', async () => {
+    userMock.statics.countDocuments.mockResolvedValue(1);
+    issuingCompanyMock.statics.countDocuments.mockResolvedValue(1);
+    process.env.DISABLE_REGISTRATION = 'true';
+
+    const res = await request(app).post('/register').send(registroValido);
+
+    expect(res.status).toBe(403);
+    expect(res.body.message).toContain('deshabilitado');
+  });
+
+  it('accepts invitation codes and RUC whitelists for subsequent registrations', async () => {
+    userMock.statics.countDocuments.mockResolvedValue(1);
+    issuingCompanyMock.statics.countDocuments.mockResolvedValue(1);
+    process.env.DISABLE_REGISTRATION = 'false';
+    process.env.INVITATION_CODES = 'INVITE001, INVITE002';
+    process.env.ALLOWED_RUCS = '';
+
+    let res = await request(app)
+      .post('/register')
+      .send({ ...registroValido, invitationCode: 'INVITE001' });
+    expect(res.status).toBe(201);
+
+    res = await request(app)
+      .post('/register')
+      .send({ ...registroValido, invitationCode: 'MALO' });
+    expect(res.status).toBe(403);
+
+    process.env.ALLOWED_RUCS = registroValido.ruc;
+    res = await request(app).post('/register').send(registroValido);
+    expect(res.status).toBe(201);
+  });
+
+  it('rejects duplicate users and companies', async () => {
+    userMock.statics.countDocuments.mockResolvedValue(1);
+    issuingCompanyMock.statics.countDocuments.mockResolvedValue(1);
+    process.env.INVITATION_CODES = 'INVITE001';
+
+    userMock.statics.findOne.mockResolvedValueOnce({ email: registroValido.email });
+    let res = await request(app)
+      .post('/register')
+      .send({ ...registroValido, invitationCode: 'INVITE001' });
+    expect(res.status).toBe(409);
+
+    userMock.statics.findOne.mockResolvedValueOnce(null);
+    issuingCompanyMock.statics.findOne.mockResolvedValueOnce({ ruc: registroValido.ruc });
+    res = await request(app)
+      .post('/register')
+      .send({ ...registroValido, invitationCode: 'INVITE001' });
+    expect(res.status).toBe(409);
+  });
+
+  it('reports the system status', async () => {
+    userMock.statics.countDocuments.mockResolvedValue(0);
+    issuingCompanyMock.statics.countDocuments.mockResolvedValue(0);
+    process.env.DISABLE_REGISTRATION = 'false';
+
+    const res = await request(app).get('/status');
+
+    expect(res.status).toBe(200);
+    expect(res.body.firstRegistration).toBe(true);
+    expect(res.body.masterKeyRequired).toBe(true);
+  });
+});

--- a/__tests__/debitNote.routes.test.ts
+++ b/__tests__/debitNote.routes.test.ts
@@ -1,0 +1,186 @@
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { createApp } from '../src/testApp';
+
+// --- Model mocks ---
+const debitNoteInstanceMocks = {
+  save: jest.fn().mockResolvedValue({}),
+};
+
+const debitNoteStaticMocks = {
+  find: jest.fn().mockResolvedValue([]),
+  findById: jest.fn().mockResolvedValue(null),
+  findOne: jest.fn().mockResolvedValue(null),
+  findByIdAndUpdate: jest.fn().mockResolvedValue(null),
+  findByIdAndDelete: jest.fn().mockResolvedValue(null),
+};
+
+jest.mock('../src/models/DebitNote', () => {
+  class MockDebitNote {
+    constructor(public data: any) {}
+    save = debitNoteInstanceMocks.save;
+    static find = (...args: any[]) => debitNoteStaticMocks.find(...args);
+    static findById = (...args: any[]) => debitNoteStaticMocks.findById(...args);
+    static findOne = (...args: any[]) => debitNoteStaticMocks.findOne(...args);
+    static findByIdAndUpdate = (...args: any[]) => debitNoteStaticMocks.findByIdAndUpdate(...args);
+    static findByIdAndDelete = (...args: any[]) => debitNoteStaticMocks.findByIdAndDelete(...args);
+  }
+  return { __esModule: true, default: MockDebitNote };
+});
+
+const debitNotePDFStaticMocks = {
+  findOne: jest.fn().mockResolvedValue(null),
+};
+
+jest.mock('../src/models/DebitNotePDF', () => ({
+  __esModule: true,
+  default: {
+    findOne: (...args: any[]) => debitNotePDFStaticMocks.findOne(...args),
+  },
+}));
+
+// --- Service mock ---
+const crearNotaDebitoCompletaMock = jest.fn();
+jest.mock('../src/services/debit-note.service', () => ({
+  DebitNoteService: {
+    crearNotaDebitoCompleta: (...args: any[]) => crearNotaDebitoCompletaMock(...args),
+  },
+}));
+
+const app = createApp();
+const token = jwt.sign({ userId: '1' }, process.env.JWT_SECRET as string);
+const authHeader = `Bearer ${token}`;
+
+const notaDebitoPayload = {
+  infoTributaria: { ruc: '1790012345001' },
+  infoNotaDebito: {
+    fechaEmision: '17/05/2025',
+    tipoIdentificacionComprador: '05',
+    identificacionComprador: '0106079783',
+    codDocModificado: '01',
+    numDocModificado: '001-001-000000123',
+    fechaEmisionDocSustento: '10/05/2025',
+    totalSinImpuestos: '50.00',
+    impuestos: [],
+    valorTotal: '57.50',
+    pagos: [],
+  },
+  motivos: [],
+};
+
+describe('Debit note routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /api/v1/debit-note/complete', () => {
+    it('requires authentication', async () => {
+      const res = await request(app).post('/api/v1/debit-note/complete').send({});
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 400 when nota_debito is missing', async () => {
+      const res = await request(app).post('/api/v1/debit-note/complete').set('Authorization', authHeader).send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(crearNotaDebitoCompletaMock).not.toHaveBeenCalled();
+    });
+
+    it('creates a complete debit note and returns its XML', async () => {
+      const resultadoMock = {
+        nota_debito: { secuencial: '000000001', clave_acceso: '123' },
+        xml: '<notaDebito/>',
+        xml_firmado: null,
+        respuesta_sri: null,
+      };
+      crearNotaDebitoCompletaMock.mockResolvedValueOnce(resultadoMock);
+
+      const res = await request(app)
+        .post('/api/v1/debit-note/complete')
+        .set('Authorization', authHeader)
+        .send({ nota_debito: notaDebitoPayload });
+
+      expect(res.status).toBe(201);
+      expect(res.body.success).toBe(true);
+      expect(res.body.xml).toBe('<notaDebito/>');
+      expect(crearNotaDebitoCompletaMock).toHaveBeenCalledWith(notaDebitoPayload);
+    });
+
+    it('returns 400 for validation errors from the service', async () => {
+      crearNotaDebitoCompletaMock.mockRejectedValueOnce(new Error('Datos de nota de débito inválidos o incompletos'));
+
+      const res = await request(app)
+        .post('/api/v1/debit-note/complete')
+        .set('Authorization', authHeader)
+        .send({ nota_debito: notaDebitoPayload });
+
+      expect(res.status).toBe(400);
+      expect(res.body.message).toContain('inválidos');
+    });
+
+    it('returns 500 for unexpected service errors', async () => {
+      crearNotaDebitoCompletaMock.mockRejectedValueOnce(new Error('mongo down'));
+
+      const res = await request(app)
+        .post('/api/v1/debit-note/complete')
+        .set('Authorization', authHeader)
+        .send({ nota_debito: notaDebitoPayload });
+
+      expect(res.status).toBe(500);
+      expect(res.body.success).toBe(false);
+    });
+  });
+
+  describe('CRUD endpoints', () => {
+    it('lists debit notes', async () => {
+      debitNoteStaticMocks.find.mockResolvedValueOnce([{ secuencial: '000000001' }]);
+
+      const res = await request(app).get('/api/v1/debit-note').set('Authorization', authHeader);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+    });
+
+    it('returns 404 for a missing debit note', async () => {
+      const res = await request(app)
+        .get('/api/v1/debit-note/507f1f77bcf86cd799439011')
+        .set('Authorization', authHeader);
+
+      expect(res.status).toBe(404);
+    });
+
+    it('returns a debit note by id', async () => {
+      debitNoteStaticMocks.findById.mockResolvedValueOnce({ secuencial: '000000001' });
+
+      const res = await request(app)
+        .get('/api/v1/debit-note/507f1f77bcf86cd799439011')
+        .set('Authorization', authHeader);
+
+      expect(res.status).toBe(200);
+      expect(res.body.secuencial).toBe('000000001');
+    });
+
+    it('returns the PDF info of a debit note', async () => {
+      debitNotePDFStaticMocks.findOne.mockResolvedValueOnce({ pdf_url: 'https://cdn/pdf.pdf', estado: 'GENERADO' });
+
+      const res = await request(app)
+        .get('/api/v1/debit-note/507f1f77bcf86cd799439011/pdf')
+        .set('Authorization', authHeader);
+
+      expect(res.status).toBe(200);
+      expect(res.body.pdf_url).toBe('https://cdn/pdf.pdf');
+    });
+
+    it('deletes a debit note', async () => {
+      debitNoteStaticMocks.findByIdAndDelete.mockResolvedValueOnce({ _id: '507f1f77bcf86cd799439011' });
+
+      const res = await request(app)
+        .delete('/api/v1/debit-note/507f1f77bcf86cd799439011')
+        .set('Authorization', authHeader);
+
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Deleted');
+    });
+  });
+});

--- a/__tests__/deliveryNote.routes.test.ts
+++ b/__tests__/deliveryNote.routes.test.ts
@@ -1,0 +1,186 @@
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { createApp } from '../src/testApp';
+
+// --- Model mocks ---
+const deliveryNoteInstanceMocks = {
+  save: jest.fn().mockResolvedValue({}),
+};
+
+const deliveryNoteStaticMocks = {
+  find: jest.fn().mockResolvedValue([]),
+  findById: jest.fn().mockResolvedValue(null),
+  findOne: jest.fn().mockResolvedValue(null),
+  findByIdAndUpdate: jest.fn().mockResolvedValue(null),
+  findByIdAndDelete: jest.fn().mockResolvedValue(null),
+};
+
+jest.mock('../src/models/DeliveryNote', () => {
+  class MockDeliveryNote {
+    constructor(public data: any) {}
+    save = deliveryNoteInstanceMocks.save;
+    static find = (...args: any[]) => deliveryNoteStaticMocks.find(...args);
+    static findById = (...args: any[]) => deliveryNoteStaticMocks.findById(...args);
+    static findOne = (...args: any[]) => deliveryNoteStaticMocks.findOne(...args);
+    static findByIdAndUpdate = (...args: any[]) => deliveryNoteStaticMocks.findByIdAndUpdate(...args);
+    static findByIdAndDelete = (...args: any[]) => deliveryNoteStaticMocks.findByIdAndDelete(...args);
+  }
+  return { __esModule: true, default: MockDeliveryNote };
+});
+
+const deliveryNotePDFStaticMocks = {
+  findOne: jest.fn().mockResolvedValue(null),
+};
+
+jest.mock('../src/models/DeliveryNotePDF', () => ({
+  __esModule: true,
+  default: {
+    findOne: (...args: any[]) => deliveryNotePDFStaticMocks.findOne(...args),
+  },
+}));
+
+// --- Service mock ---
+const crearGuiaRemisionCompletaMock = jest.fn();
+jest.mock('../src/services/delivery-note.service', () => ({
+  DeliveryNoteService: {
+    crearGuiaRemisionCompleta: (...args: any[]) => crearGuiaRemisionCompletaMock(...args),
+  },
+}));
+
+const app = createApp();
+const token = jwt.sign({ userId: '1' }, process.env.JWT_SECRET as string);
+const authHeader = `Bearer ${token}`;
+
+const guiaRemisionPayload = {
+  infoTributaria: { ruc: '1790012345001' },
+  infoGuiaRemision: {
+    fechaEmision: '17/05/2025',
+    dirPartida: 'Av. Eloy Alfaro 34',
+    razonSocialTransportista: 'Transportes S.A.',
+    tipoIdentificacionTransportista: '04',
+    rucTransportista: '1796875790001',
+    fechaIniTransporte: '17/05/2025',
+    fechaFinTransporte: '18/05/2025',
+    placa: 'MCL0827',
+  },
+  destinatarios: [],
+};
+
+describe('Delivery note routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /api/v1/delivery-note/complete', () => {
+    it('requires authentication', async () => {
+      const res = await request(app).post('/api/v1/delivery-note/complete').send({});
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 400 when guia_remision is missing', async () => {
+      const res = await request(app).post('/api/v1/delivery-note/complete').set('Authorization', authHeader).send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(crearGuiaRemisionCompletaMock).not.toHaveBeenCalled();
+    });
+
+    it('creates a complete delivery note and returns its XML', async () => {
+      const resultadoMock = {
+        guia_remision: { secuencial: '000000001', clave_acceso: '123' },
+        xml: '<guiaRemision/>',
+        xml_firmado: null,
+        respuesta_sri: null,
+      };
+      crearGuiaRemisionCompletaMock.mockResolvedValueOnce(resultadoMock);
+
+      const res = await request(app)
+        .post('/api/v1/delivery-note/complete')
+        .set('Authorization', authHeader)
+        .send({ guia_remision: guiaRemisionPayload });
+
+      expect(res.status).toBe(201);
+      expect(res.body.success).toBe(true);
+      expect(res.body.xml).toBe('<guiaRemision/>');
+      expect(crearGuiaRemisionCompletaMock).toHaveBeenCalledWith(guiaRemisionPayload);
+    });
+
+    it('returns 400 for validation errors from the service', async () => {
+      crearGuiaRemisionCompletaMock.mockRejectedValueOnce(
+        new Error('Datos de guía de remisión inválidos o incompletos'),
+      );
+
+      const res = await request(app)
+        .post('/api/v1/delivery-note/complete')
+        .set('Authorization', authHeader)
+        .send({ guia_remision: guiaRemisionPayload });
+
+      expect(res.status).toBe(400);
+      expect(res.body.message).toContain('inválidos');
+    });
+
+    it('returns 500 for unexpected service errors', async () => {
+      crearGuiaRemisionCompletaMock.mockRejectedValueOnce(new Error('mongo down'));
+
+      const res = await request(app)
+        .post('/api/v1/delivery-note/complete')
+        .set('Authorization', authHeader)
+        .send({ guia_remision: guiaRemisionPayload });
+
+      expect(res.status).toBe(500);
+      expect(res.body.success).toBe(false);
+    });
+  });
+
+  describe('CRUD endpoints', () => {
+    it('lists delivery notes', async () => {
+      deliveryNoteStaticMocks.find.mockResolvedValueOnce([{ secuencial: '000000001' }]);
+
+      const res = await request(app).get('/api/v1/delivery-note').set('Authorization', authHeader);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+    });
+
+    it('returns 404 for a missing delivery note', async () => {
+      const res = await request(app)
+        .get('/api/v1/delivery-note/507f1f77bcf86cd799439011')
+        .set('Authorization', authHeader);
+
+      expect(res.status).toBe(404);
+    });
+
+    it('returns a delivery note by id', async () => {
+      deliveryNoteStaticMocks.findById.mockResolvedValueOnce({ secuencial: '000000001' });
+
+      const res = await request(app)
+        .get('/api/v1/delivery-note/507f1f77bcf86cd799439011')
+        .set('Authorization', authHeader);
+
+      expect(res.status).toBe(200);
+      expect(res.body.secuencial).toBe('000000001');
+    });
+
+    it('returns the PDF info of a delivery note', async () => {
+      deliveryNotePDFStaticMocks.findOne.mockResolvedValueOnce({ pdf_url: 'https://cdn/pdf.pdf', estado: 'GENERADO' });
+
+      const res = await request(app)
+        .get('/api/v1/delivery-note/507f1f77bcf86cd799439011/pdf')
+        .set('Authorization', authHeader);
+
+      expect(res.status).toBe(200);
+      expect(res.body.pdf_url).toBe('https://cdn/pdf.pdf');
+    });
+
+    it('deletes a delivery note', async () => {
+      deliveryNoteStaticMocks.findByIdAndDelete.mockResolvedValueOnce({ _id: '507f1f77bcf86cd799439011' });
+
+      const res = await request(app)
+        .delete('/api/v1/delivery-note/507f1f77bcf86cd799439011')
+        .set('Authorization', authHeader);
+
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Deleted');
+    });
+  });
+});

--- a/__tests__/services/creditNote.service.test.ts
+++ b/__tests__/services/creditNote.service.test.ts
@@ -1,0 +1,450 @@
+import fs from 'fs';
+
+// --- Mocks for collaborators ---
+const firmarXMLMock = jest.fn().mockResolvedValue('<notaCredito>firmada</notaCredito>');
+jest.mock('../../src/utils/firma.utils', () => ({
+  firmarXML: (...args: any[]) => firmarXMLMock(...args),
+}));
+
+const enviarComprobanteSRIMock = jest.fn();
+const autorizarComprobanteSRIMock = jest.fn();
+jest.mock('../../src/utils/sri.utils', () => ({
+  enviarComprobanteSRI: (...args: any[]) => enviarComprobanteSRIMock(...args),
+  autorizarComprobanteSRI: (...args: any[]) => autorizarComprobanteSRIMock(...args),
+}));
+
+const generateCreditNotePDFMock = jest.fn().mockResolvedValue(Buffer.from('pdf'));
+jest.mock('../../src/utils/pdf.utils', () => ({
+  generateCreditNotePDF: (...args: any[]) => generateCreditNotePDFMock(...args),
+}));
+
+const storageUploadMock = jest.fn().mockResolvedValue({
+  url: 'https://cdn/nc.pdf',
+  publicId: 'nc-1',
+  provider: 'local',
+  size: 3,
+});
+jest.mock('../../src/services/storage', () => ({
+  PDFStorageFactory: { create: () => ({ upload: storageUploadMock, getProviderName: () => 'local' }) },
+}));
+
+const invoiceServiceMocks = {
+  buscarTipoIdentificacion: jest.fn(),
+  buscarIssuingCompany: jest.fn(),
+  buscarClient: jest.fn(),
+  buscarProduct: jest.fn(),
+  diagnoseP12Certificate: jest.fn(),
+  verifyP12Password: jest.fn(),
+  findWorkingP12Password: jest.fn(),
+};
+jest.mock('../../src/services/invoice.service', () => ({
+  InvoiceService: invoiceServiceMocks,
+}));
+
+// --- Model mocks ---
+const savedCreditNotes: any[] = [];
+const creditNoteStatics = {
+  findOne: jest.fn(),
+  findById: jest.fn(),
+};
+jest.mock('../../src/models/CreditNote', () => {
+  class MockCreditNote {
+    [key: string]: any;
+    constructor(data: any) {
+      Object.assign(this, data);
+      this._id = 'cn-1';
+      savedCreditNotes.push(this);
+    }
+    save = jest.fn().mockResolvedValue(this);
+    static findOne = (...args: any[]) => creditNoteStatics.findOne(...args);
+    static findById = (...args: any[]) => creditNoteStatics.findById(...args);
+  }
+  return { __esModule: true, default: MockCreditNote };
+});
+
+const savedDetails: any[] = [];
+jest.mock('../../src/models/CreditNoteDetail', () => {
+  class MockDetail {
+    [key: string]: any;
+    constructor(data: any) {
+      Object.assign(this, data);
+      savedDetails.push(this);
+    }
+    save = jest.fn().mockResolvedValue(this);
+  }
+  return { __esModule: true, default: MockDetail };
+});
+
+const savedPDFs: any[] = [];
+jest.mock('../../src/models/CreditNotePDF', () => {
+  class MockPDF {
+    [key: string]: any;
+    constructor(data: any) {
+      Object.assign(this, data);
+      savedPDFs.push(this);
+    }
+    save = jest.fn().mockResolvedValue(this);
+  }
+  return { __esModule: true, default: MockPDF };
+});
+
+const invoiceStatics = { findOne: jest.fn().mockResolvedValue(null) };
+jest.mock('../../src/models/Invoice', () => ({
+  __esModule: true,
+  default: { findOne: (...args: any[]) => invoiceStatics.findOne(...args) },
+}));
+
+const issuingCompanyStatics = { findOne: jest.fn() };
+jest.mock('../../src/models/IssuingCompany', () => ({
+  __esModule: true,
+  default: { findOne: (...args: any[]) => issuingCompanyStatics.findOne(...args) },
+}));
+
+import { CreditNoteService } from '../../src/services/credit-note.service';
+import { CreditNoteRequest } from '../../src/interfaces/credit-note.interface';
+
+const empresaMock: any = {
+  _id: 'empresa-1',
+  ruc: '1790012345001',
+  razon_social: 'EMPRESA DEMO S.A.',
+  nombre_comercial: 'DEMO',
+  codigo_establecimiento: '001',
+  punto_emision: '001',
+  tipo_ambiente: 1,
+  tipo_emision: 1,
+  direccion_matriz: 'Av. Principal',
+  direccion_establecimiento: 'Av. Principal',
+  obligado_contabilidad: true,
+  certificatePath: '/tmp/cert.p12',
+  certificatePassword: 'test-cert-password',
+};
+
+const clienteMock: any = { _id: 'cliente-1', razon_social: 'CLIENTE', identificacion: '0106079783' };
+const productoMock: any = { _id: 'producto-1', codigo: 'P001' };
+
+const requestValido: CreditNoteRequest = {
+  infoTributaria: { ruc: empresaMock.ruc, claveAcceso: '', secuencial: '' },
+  infoNotaCredito: {
+    fechaEmision: '17/05/2025',
+    tipoIdentificacionComprador: '05',
+    identificacionComprador: clienteMock.identificacion,
+    codDocModificado: '01',
+    numDocModificado: '001-001-000000123',
+    fechaEmisionDocSustento: '10/05/2025',
+    totalSinImpuestos: '100.00',
+    valorModificacion: '115.00',
+    motivo: 'DEVOLUCIÓN',
+  },
+  detalles: [
+    {
+      detalle: {
+        codigoInterno: 'P001',
+        descripcion: 'Laptop',
+        cantidad: '1.00',
+        precioUnitario: '100.00',
+        precioTotalSinImpuesto: '100.00',
+        impuestos: [
+          {
+            impuesto: { codigo: '2', codigoPorcentaje: '4', tarifa: '15.00', baseImponible: '100.00', valor: '15.00' },
+          },
+        ],
+      },
+    },
+  ],
+};
+
+function prepararLookupsFelices() {
+  invoiceServiceMocks.buscarTipoIdentificacion.mockResolvedValue({ codigo: '05' });
+  invoiceServiceMocks.buscarIssuingCompany.mockResolvedValue(empresaMock);
+  invoiceServiceMocks.buscarClient.mockResolvedValue(clienteMock);
+  invoiceServiceMocks.buscarProduct.mockResolvedValue(productoMock);
+  issuingCompanyStatics.findOne.mockResolvedValue(empresaMock);
+  creditNoteStatics.findOne.mockReturnValue({ sort: jest.fn().mockResolvedValue(null) });
+}
+
+describe('CreditNoteService', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+    savedCreditNotes.length = 0;
+    savedDetails.length = 0;
+    savedPDFs.length = 0;
+    prepararLookupsFelices();
+  });
+
+  describe('validarDatosNotaCredito', () => {
+    it('accepts a complete request', () => {
+      expect(CreditNoteService.validarDatosNotaCredito(requestValido)).toBe(true);
+    });
+
+    it('rejects requests without detalles or motivo', () => {
+      expect(CreditNoteService.validarDatosNotaCredito({ ...requestValido, detalles: [] })).toBe(false);
+      expect(
+        CreditNoteService.validarDatosNotaCredito({
+          ...requestValido,
+          infoNotaCredito: { ...requestValido.infoNotaCredito, motivo: '' },
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('generarSecuencial', () => {
+    it('starts at 000000001 when there are no credit notes', async () => {
+      await expect(CreditNoteService.generarSecuencial(empresaMock.ruc)).resolves.toBe('000000001');
+    });
+
+    it('increments the latest secuencial', async () => {
+      creditNoteStatics.findOne.mockReturnValue({ sort: jest.fn().mockResolvedValue({ secuencial: '000000041' }) });
+
+      await expect(CreditNoteService.generarSecuencial(empresaMock.ruc)).resolves.toBe('000000042');
+    });
+
+    it('throws when the empresa does not exist', async () => {
+      issuingCompanyStatics.findOne.mockResolvedValue(null);
+
+      await expect(CreditNoteService.generarSecuencial('999')).rejects.toThrow('not found');
+    });
+  });
+
+  describe('procesarNotaCreditoCompleta', () => {
+    it.each([
+      [
+        'identification type',
+        () => invoiceServiceMocks.buscarTipoIdentificacion.mockResolvedValue(null),
+        'Identification type not found',
+      ],
+      [
+        'empresa',
+        () => invoiceServiceMocks.buscarIssuingCompany.mockResolvedValue(null),
+        'Empresa emisora no encontrada',
+      ],
+      ['client', () => invoiceServiceMocks.buscarClient.mockResolvedValue(null), 'Client not found'],
+      ['product', () => invoiceServiceMocks.buscarProduct.mockResolvedValue(null), 'Product not found'],
+    ])('fails when the %s is missing', async (_name, arrange, mensaje) => {
+      arrange();
+
+      await expect(CreditNoteService.procesarNotaCreditoCompleta(requestValido)).rejects.toThrow(mensaje);
+    });
+
+    it('fails on invalid dates', async () => {
+      const invalido = {
+        ...requestValido,
+        infoNotaCredito: { ...requestValido.infoNotaCredito, fechaEmision: 'fecha-mala' },
+      };
+
+      await expect(CreditNoteService.procesarNotaCreditoCompleta(invalido)).rejects.toThrow('Invalid date format');
+    });
+
+    it('resolves every entity and links the modified invoice when it exists', async () => {
+      invoiceStatics.findOne.mockResolvedValue({ _id: 'factura-99' });
+
+      const resultado = await CreditNoteService.procesarNotaCreditoCompleta(requestValido);
+
+      expect(resultado.empresa).toBe(empresaMock);
+      expect(resultado.cliente).toBe(clienteMock);
+      expect(resultado.secuencial).toBe('000000001');
+      expect(resultado.facturaModificada).toEqual({ _id: 'factura-99' });
+      expect(invoiceStatics.findOne).toHaveBeenCalledWith(expect.objectContaining({ secuencial: '000000123' }));
+    });
+  });
+
+  describe('crearNotaCreditoCompleta', () => {
+    beforeEach(() => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(false); // skip real SRI flow in background
+    });
+
+    it('creates the credit note with an 04 access key, XML and details', async () => {
+      const resultado = await CreditNoteService.crearNotaCreditoCompleta(requestValido);
+
+      expect(resultado.nota_credito.clave_acceso).toHaveLength(49);
+      expect(resultado.nota_credito.clave_acceso.substring(8, 10)).toBe('04');
+      expect(resultado.xml).toContain('<notaCredito id="comprobante" version="1.1.0">');
+      expect(resultado.nota_credito.total_iva).toBe(15);
+      expect(resultado.nota_credito.valor_modificacion).toBe(115);
+      expect(resultado.detalles).toHaveLength(1);
+      expect(savedDetails[0].producto_id).toBe('producto-1');
+    });
+  });
+
+  describe('procesarEnvioSRI', () => {
+    const notaCreditoDoc: any = () => ({
+      _id: 'cn-1',
+      xml: '<notaCredito/>',
+      clave_acceso: 'clave',
+      secuencial: '000000001',
+      fecha_emision: new Date(),
+      save: jest.fn().mockResolvedValue(undefined),
+    });
+
+    it('marks ERROR_FIRMA when there is no certificate', async () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+      const doc = notaCreditoDoc();
+
+      await CreditNoteService.procesarEnvioSRI(
+        doc,
+        { ...empresaMock, certificatePath: undefined },
+        clienteMock,
+        [],
+        requestValido,
+      );
+
+      expect(doc.sri_estado).toBe('ERROR_FIRMA');
+      expect(firmarXMLMock).not.toHaveBeenCalled();
+    });
+
+    it('signs with tipoDocumento 04, sends, generates the PDF and schedules authorization on RECIBIDA', async () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+      invoiceServiceMocks.diagnoseP12Certificate.mockResolvedValue({ isValidP12: true });
+      invoiceServiceMocks.verifyP12Password.mockResolvedValue({ valid: true });
+      enviarComprobanteSRIMock.mockResolvedValue({ estado: 'RECIBIDA' });
+      const programarSpy = jest.spyOn(CreditNoteService, 'programarConsultaAutorizacion').mockImplementation(() => {});
+      const doc = notaCreditoDoc();
+
+      await CreditNoteService.procesarEnvioSRI(doc, empresaMock, clienteMock, [productoMock], requestValido);
+
+      expect(firmarXMLMock).toHaveBeenCalledWith(
+        '<notaCredito/>',
+        empresaMock.certificatePath,
+        'test-cert-password',
+        '04',
+      );
+      expect(doc.xml_firmado).toBe('<notaCredito>firmada</notaCredito>');
+      expect(doc.sri_estado).toBe('RECIBIDA');
+      expect(generateCreditNotePDFMock).toHaveBeenCalled();
+      expect(savedPDFs[0].estado).toBe('GENERADO');
+      expect(programarSpy).toHaveBeenCalledWith('cn-1');
+    });
+
+    it('records the DEVUELTA state without generating a PDF', async () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+      invoiceServiceMocks.diagnoseP12Certificate.mockResolvedValue({ isValidP12: true });
+      invoiceServiceMocks.verifyP12Password.mockResolvedValue({ valid: true });
+      enviarComprobanteSRIMock.mockResolvedValue({
+        estado: 'DEVUELTA',
+        mensajes: { mensaje: { identificador: '35' } },
+      });
+      const doc = notaCreditoDoc();
+
+      await CreditNoteService.procesarEnvioSRI(doc, empresaMock, clienteMock, [], requestValido);
+
+      expect(doc.sri_estado).toBe('DEVUELTA');
+      expect(doc.sri_mensajes).toEqual({ mensaje: { identificador: '35' } });
+      expect(generateCreditNotePDFMock).not.toHaveBeenCalled();
+    });
+
+    it('falls back to an alternative password when verification fails', async () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+      invoiceServiceMocks.diagnoseP12Certificate.mockResolvedValue({ isValidP12: true });
+      invoiceServiceMocks.verifyP12Password.mockResolvedValue({ valid: false, error: 'bad mac' });
+      invoiceServiceMocks.findWorkingP12Password.mockResolvedValue({ password: 'test-fallback-password' });
+      enviarComprobanteSRIMock.mockResolvedValue({ estado: 'RECIBIDA' });
+      jest.spyOn(CreditNoteService, 'programarConsultaAutorizacion').mockImplementation(() => {});
+      const doc = notaCreditoDoc();
+
+      await CreditNoteService.procesarEnvioSRI(doc, empresaMock, clienteMock, [], requestValido);
+
+      expect(firmarXMLMock).toHaveBeenCalledWith(expect.anything(), expect.anything(), 'test-fallback-password', '04');
+    });
+
+    it('marks ERROR_FIRMA when no password works', async () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+      invoiceServiceMocks.diagnoseP12Certificate.mockResolvedValue({ isValidP12: true });
+      invoiceServiceMocks.verifyP12Password.mockResolvedValue({ valid: false, error: 'bad mac' });
+      invoiceServiceMocks.findWorkingP12Password.mockResolvedValue({ password: null });
+      const doc = notaCreditoDoc();
+
+      await CreditNoteService.procesarEnvioSRI(doc, empresaMock, clienteMock, [], requestValido);
+
+      expect(doc.sri_estado).toBe('ERROR_FIRMA');
+      expect(doc.sri_mensajes.error).toContain('contraseña');
+    });
+  });
+
+  describe('consultarAutorizacionSRI', () => {
+    it('updates the credit note when the SRI authorizes it', async () => {
+      const doc: any = {
+        clave_acceso: 'clave',
+        secuencial: '000000001',
+        save: jest.fn().mockResolvedValue(undefined),
+      };
+      creditNoteStatics.findById.mockResolvedValue(doc);
+      autorizarComprobanteSRIMock.mockResolvedValue({
+        estado: 'AUTORIZADO',
+        numeroAutorizacion: 'clave',
+        fechaAutorizacion: '2025-05-17T12:00:00-05:00',
+      });
+
+      const resultado = await CreditNoteService.consultarAutorizacionSRI('cn-1');
+
+      expect(resultado?.estado).toBe('AUTORIZADO');
+      expect(doc.estado).toBe('AUTORIZADA');
+      expect(doc.autorizacion_numero).toBe('clave');
+      expect(doc.fecha_autorizacion).toBeInstanceOf(Date);
+      expect(doc.save).toHaveBeenCalled();
+    });
+
+    it('keeps the document pending when the SRI is still processing', async () => {
+      const doc: any = { clave_acceso: 'clave', save: jest.fn().mockResolvedValue(undefined) };
+      creditNoteStatics.findById.mockResolvedValue(doc);
+      autorizarComprobanteSRIMock.mockResolvedValue({ estado: 'EN PROCESO' });
+
+      const resultado = await CreditNoteService.consultarAutorizacionSRI('cn-1');
+
+      expect(resultado?.estado).toBe('EN PROCESO');
+      expect(doc.estado).toBeUndefined();
+    });
+
+    it('returns null when the credit note does not exist', async () => {
+      creditNoteStatics.findById.mockResolvedValue(null);
+
+      await expect(CreditNoteService.consultarAutorizacionSRI('nope')).resolves.toBeNull();
+    });
+  });
+
+  describe('programarConsultaAutorizacion', () => {
+    beforeEach(() => jest.useFakeTimers());
+    afterEach(() => jest.useRealTimers());
+
+    it('retries while the receipt is pending, up to the max attempts', async () => {
+      const consultarSpy = jest
+        .spyOn(CreditNoteService, 'consultarAutorizacionSRI')
+        .mockResolvedValue({ estado: 'EN PROCESO' } as any);
+
+      CreditNoteService.programarConsultaAutorizacion('cn-1', 1, 3, 1000);
+      await jest.advanceTimersByTimeAsync(1000);
+      await jest.advanceTimersByTimeAsync(1000);
+      await jest.advanceTimersByTimeAsync(1000);
+      await jest.advanceTimersByTimeAsync(1000);
+
+      expect(consultarSpy).toHaveBeenCalledTimes(3);
+    });
+
+    it('stops retrying once the receipt is authorized', async () => {
+      const consultarSpy = jest
+        .spyOn(CreditNoteService, 'consultarAutorizacionSRI')
+        .mockResolvedValue({ estado: 'AUTORIZADO' } as any);
+
+      CreditNoteService.programarConsultaAutorizacion('cn-1', 1, 3, 1000);
+      await jest.advanceTimersByTimeAsync(3000);
+
+      expect(consultarSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('generarPDFNotaCredito', () => {
+    it('stores an ERROR record when the PDF generation fails', async () => {
+      generateCreditNotePDFMock.mockRejectedValueOnce(new Error('render failed'));
+      const doc: any = {
+        _id: 'cn-1',
+        clave_acceso: 'clave',
+        secuencial: '000000001',
+        fecha_emision: new Date(),
+      };
+
+      await CreditNoteService.generarPDFNotaCredito(doc, empresaMock, clienteMock, [], requestValido);
+
+      expect(savedPDFs[0].estado).toBe('ERROR');
+      expect(savedPDFs[0].pdf_provider).toBe('error');
+    });
+  });
+});

--- a/__tests__/services/debitNote.service.test.ts
+++ b/__tests__/services/debitNote.service.test.ts
@@ -1,0 +1,306 @@
+import fs from 'fs';
+
+const firmarXMLMock = jest.fn().mockResolvedValue('<notaDebito>firmada</notaDebito>');
+jest.mock('../../src/utils/firma.utils', () => ({
+  firmarXML: (...args: any[]) => firmarXMLMock(...args),
+}));
+
+const enviarComprobanteSRIMock = jest.fn();
+const autorizarComprobanteSRIMock = jest.fn();
+jest.mock('../../src/utils/sri.utils', () => ({
+  enviarComprobanteSRI: (...args: any[]) => enviarComprobanteSRIMock(...args),
+  autorizarComprobanteSRI: (...args: any[]) => autorizarComprobanteSRIMock(...args),
+}));
+
+const generateDebitNotePDFMock = jest.fn().mockResolvedValue(Buffer.from('pdf'));
+jest.mock('../../src/utils/pdf.utils', () => ({
+  generateDebitNotePDF: (...args: any[]) => generateDebitNotePDFMock(...args),
+}));
+
+const storageUploadMock = jest
+  .fn()
+  .mockResolvedValue({ url: 'https://cdn/nd.pdf', publicId: 'nd-1', provider: 'local', size: 3 });
+jest.mock('../../src/services/storage', () => ({
+  PDFStorageFactory: { create: () => ({ upload: storageUploadMock, getProviderName: () => 'local' }) },
+}));
+
+const invoiceServiceMocks = {
+  buscarTipoIdentificacion: jest.fn(),
+  buscarIssuingCompany: jest.fn(),
+  buscarClient: jest.fn(),
+  diagnoseP12Certificate: jest.fn(),
+  verifyP12Password: jest.fn(),
+  findWorkingP12Password: jest.fn(),
+};
+jest.mock('../../src/services/invoice.service', () => ({ InvoiceService: invoiceServiceMocks }));
+
+const debitNoteStatics = { findOne: jest.fn(), findById: jest.fn() };
+const savedDebitNotes: any[] = [];
+jest.mock('../../src/models/DebitNote', () => {
+  class MockDebitNote {
+    [key: string]: any;
+    constructor(data: any) {
+      Object.assign(this, data);
+      this._id = 'nd-1';
+      savedDebitNotes.push(this);
+    }
+    save = jest.fn().mockResolvedValue(this);
+    static findOne = (...args: any[]) => debitNoteStatics.findOne(...args);
+    static findById = (...args: any[]) => debitNoteStatics.findById(...args);
+  }
+  return { __esModule: true, default: MockDebitNote };
+});
+
+const savedPDFs: any[] = [];
+jest.mock('../../src/models/DebitNotePDF', () => {
+  class MockPDF {
+    [key: string]: any;
+    constructor(data: any) {
+      Object.assign(this, data);
+      savedPDFs.push(this);
+    }
+    save = jest.fn().mockResolvedValue(this);
+  }
+  return { __esModule: true, default: MockPDF };
+});
+
+jest.mock('../../src/models/Invoice', () => ({
+  __esModule: true,
+  default: { findOne: jest.fn().mockResolvedValue(null) },
+}));
+
+const issuingCompanyStatics = { findOne: jest.fn() };
+jest.mock('../../src/models/IssuingCompany', () => ({
+  __esModule: true,
+  default: { findOne: (...args: any[]) => issuingCompanyStatics.findOne(...args) },
+}));
+
+import { DebitNoteService } from '../../src/services/debit-note.service';
+import { DebitNoteRequest } from '../../src/interfaces/debit-note.interface';
+
+const empresaMock: any = {
+  _id: 'empresa-1',
+  ruc: '1790012345001',
+  razon_social: 'EMPRESA DEMO S.A.',
+  nombre_comercial: 'DEMO',
+  codigo_establecimiento: '001',
+  punto_emision: '001',
+  tipo_ambiente: 1,
+  tipo_emision: 1,
+  direccion_matriz: 'Av. Principal',
+  direccion_establecimiento: 'Av. Principal',
+  obligado_contabilidad: true,
+  certificatePath: '/tmp/cert.p12',
+  certificatePassword: 'test-cert-password',
+};
+
+const clienteMock: any = { _id: 'cliente-1', razon_social: 'CLIENTE', identificacion: '0106079783' };
+
+const requestValido: DebitNoteRequest = {
+  infoTributaria: { ruc: empresaMock.ruc, claveAcceso: '', secuencial: '' },
+  infoNotaDebito: {
+    fechaEmision: '17/05/2025',
+    tipoIdentificacionComprador: '05',
+    identificacionComprador: clienteMock.identificacion,
+    codDocModificado: '01',
+    numDocModificado: '001-001-000000123',
+    fechaEmisionDocSustento: '10/05/2025',
+    totalSinImpuestos: '50.00',
+    impuestos: [
+      { impuesto: { codigo: '2', codigoPorcentaje: '4', tarifa: '15.00', baseImponible: '50.00', valor: '7.50' } },
+    ],
+    valorTotal: '57.50',
+    pagos: [{ pago: { formaPago: '20', total: '57.50' } }],
+  },
+  motivos: [{ motivo: { razon: 'Interés por mora', valor: '50.00' } }],
+};
+
+describe('DebitNoteService', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+    savedDebitNotes.length = 0;
+    savedPDFs.length = 0;
+    invoiceServiceMocks.buscarTipoIdentificacion.mockResolvedValue({ codigo: '05' });
+    invoiceServiceMocks.buscarIssuingCompany.mockResolvedValue(empresaMock);
+    invoiceServiceMocks.buscarClient.mockResolvedValue(clienteMock);
+    issuingCompanyStatics.findOne.mockResolvedValue(empresaMock);
+    debitNoteStatics.findOne.mockReturnValue({ sort: jest.fn().mockResolvedValue(null) });
+  });
+
+  describe('validarDatosNotaDebito', () => {
+    it('accepts a complete request', () => {
+      expect(DebitNoteService.validarDatosNotaDebito(requestValido)).toBe(true);
+    });
+
+    it('rejects requests without motivos, impuestos or pagos', () => {
+      expect(DebitNoteService.validarDatosNotaDebito({ ...requestValido, motivos: [] })).toBe(false);
+      expect(
+        DebitNoteService.validarDatosNotaDebito({
+          ...requestValido,
+          infoNotaDebito: { ...requestValido.infoNotaDebito, impuestos: [] },
+        }),
+      ).toBe(false);
+      expect(
+        DebitNoteService.validarDatosNotaDebito({
+          ...requestValido,
+          infoNotaDebito: { ...requestValido.infoNotaDebito, pagos: [] },
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('generarSecuencial', () => {
+    it('increments the latest secuencial', async () => {
+      debitNoteStatics.findOne.mockReturnValue({ sort: jest.fn().mockResolvedValue({ secuencial: '000000009' }) });
+
+      await expect(DebitNoteService.generarSecuencial(empresaMock.ruc)).resolves.toBe('000000010');
+    });
+
+    it('throws when the empresa does not exist', async () => {
+      issuingCompanyStatics.findOne.mockResolvedValue(null);
+
+      await expect(DebitNoteService.generarSecuencial('999')).rejects.toThrow('not found');
+    });
+  });
+
+  describe('procesarNotaDebitoCompleta', () => {
+    it('fails when the client is missing', async () => {
+      invoiceServiceMocks.buscarClient.mockResolvedValue(null);
+
+      await expect(DebitNoteService.procesarNotaDebitoCompleta(requestValido)).rejects.toThrow('Client not found');
+    });
+
+    it('fails on invalid dates', async () => {
+      const invalido = {
+        ...requestValido,
+        infoNotaDebito: { ...requestValido.infoNotaDebito, fechaEmisionDocSustento: 'mala' },
+      };
+
+      await expect(DebitNoteService.procesarNotaDebitoCompleta(invalido)).rejects.toThrow('Invalid date format');
+    });
+  });
+
+  describe('crearNotaDebitoCompleta', () => {
+    it('creates the debit note with an 05 access key, totals and motivos', async () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+      const resultado = await DebitNoteService.crearNotaDebitoCompleta(requestValido);
+
+      expect(resultado.nota_debito.clave_acceso).toHaveLength(49);
+      expect(resultado.nota_debito.clave_acceso.substring(8, 10)).toBe('05');
+      expect(resultado.xml).toContain('<notaDebito id="comprobante" version="1.0.0">');
+      expect(resultado.nota_debito.total_impuestos).toBe(7.5);
+      expect(resultado.nota_debito.valor_total).toBe(57.5);
+      expect(resultado.nota_debito.motivos).toEqual([{ razon: 'Interés por mora', valor: 50 }]);
+    });
+  });
+
+  describe('procesarEnvioSRI', () => {
+    const doc = () => ({
+      _id: 'nd-1',
+      xml: '<notaDebito/>',
+      clave_acceso: 'clave',
+      secuencial: '000000001',
+      fecha_emision: new Date(),
+      save: jest.fn().mockResolvedValue(undefined),
+    });
+
+    it('marks ERROR_FIRMA when there is no certificate', async () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+      const nota: any = doc();
+
+      await DebitNoteService.procesarEnvioSRI(
+        nota,
+        { ...empresaMock, certificatePath: undefined },
+        clienteMock,
+        requestValido,
+      );
+
+      expect(nota.sri_estado).toBe('ERROR_FIRMA');
+    });
+
+    it('signs with tipoDocumento 05 and completes the RECIBIDA flow', async () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+      invoiceServiceMocks.diagnoseP12Certificate.mockResolvedValue({ isValidP12: true });
+      invoiceServiceMocks.verifyP12Password.mockResolvedValue({ valid: true });
+      enviarComprobanteSRIMock.mockResolvedValue({ estado: 'RECIBIDA' });
+      const programarSpy = jest.spyOn(DebitNoteService, 'programarConsultaAutorizacion').mockImplementation(() => {});
+      const nota: any = doc();
+
+      await DebitNoteService.procesarEnvioSRI(nota, empresaMock, clienteMock, requestValido);
+
+      expect(firmarXMLMock).toHaveBeenCalledWith(
+        '<notaDebito/>',
+        empresaMock.certificatePath,
+        'test-cert-password',
+        '05',
+      );
+      expect(nota.sri_estado).toBe('RECIBIDA');
+      expect(generateDebitNotePDFMock).toHaveBeenCalled();
+      expect(savedPDFs[0].estado).toBe('GENERADO');
+      expect(programarSpy).toHaveBeenCalledWith('nd-1');
+    });
+
+    it('records signing errors as ERROR_FIRMA', async () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+      invoiceServiceMocks.diagnoseP12Certificate.mockResolvedValue({ isValidP12: false, error: 'corrupt' });
+      const nota: any = doc();
+
+      await DebitNoteService.procesarEnvioSRI(nota, empresaMock, clienteMock, requestValido);
+
+      expect(nota.sri_estado).toBe('ERROR_FIRMA');
+      expect(nota.sri_mensajes.error).toContain('P12');
+    });
+  });
+
+  describe('consultarAutorizacionSRI', () => {
+    it('updates the debit note when the SRI authorizes it', async () => {
+      const nota: any = {
+        clave_acceso: 'clave',
+        secuencial: '000000001',
+        save: jest.fn().mockResolvedValue(undefined),
+      };
+      debitNoteStatics.findById.mockResolvedValue(nota);
+      autorizarComprobanteSRIMock.mockResolvedValue({ estado: 'AUTORIZADO', numeroAutorizacion: 'clave' });
+
+      const resultado = await DebitNoteService.consultarAutorizacionSRI('nd-1');
+
+      expect(resultado?.estado).toBe('AUTORIZADO');
+      expect(nota.estado).toBe('AUTORIZADA');
+    });
+
+    it('returns null when the debit note does not exist', async () => {
+      debitNoteStatics.findById.mockResolvedValue(null);
+
+      await expect(DebitNoteService.consultarAutorizacionSRI('nope')).resolves.toBeNull();
+    });
+  });
+
+  describe('programarConsultaAutorizacion', () => {
+    beforeEach(() => jest.useFakeTimers());
+    afterEach(() => jest.useRealTimers());
+
+    it('retries while pending and stops at maxIntentos', async () => {
+      const consultarSpy = jest
+        .spyOn(DebitNoteService, 'consultarAutorizacionSRI')
+        .mockResolvedValue({ estado: 'EN PROCESO' } as any);
+
+      DebitNoteService.programarConsultaAutorizacion('nd-1', 1, 2, 500);
+      await jest.advanceTimersByTimeAsync(2000);
+
+      expect(consultarSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('generarPDFNotaDebito', () => {
+    it('stores an ERROR record when the PDF generation fails', async () => {
+      generateDebitNotePDFMock.mockRejectedValueOnce(new Error('render failed'));
+      const nota: any = { _id: 'nd-1', clave_acceso: 'clave', secuencial: '000000001', fecha_emision: new Date() };
+
+      await DebitNoteService.generarPDFNotaDebito(nota, empresaMock, clienteMock, requestValido);
+
+      expect(savedPDFs[0].estado).toBe('ERROR');
+    });
+  });
+});

--- a/__tests__/services/deliveryNote.service.test.ts
+++ b/__tests__/services/deliveryNote.service.test.ts
@@ -1,0 +1,432 @@
+import fs from 'fs';
+
+const firmarXMLMock = jest.fn().mockResolvedValue('<guiaRemision>firmada</guiaRemision>');
+jest.mock('../../src/utils/firma.utils', () => ({
+  firmarXML: (...args: any[]) => firmarXMLMock(...args),
+}));
+
+const enviarComprobanteSRIMock = jest.fn();
+const autorizarComprobanteSRIMock = jest.fn();
+jest.mock('../../src/utils/sri.utils', () => ({
+  enviarComprobanteSRI: (...args: any[]) => enviarComprobanteSRIMock(...args),
+  autorizarComprobanteSRI: (...args: any[]) => autorizarComprobanteSRIMock(...args),
+}));
+
+const generateDeliveryNotePDFMock = jest.fn().mockResolvedValue(Buffer.from('pdf'));
+jest.mock('../../src/utils/pdf.utils', () => ({
+  generateDeliveryNotePDF: (...args: any[]) => generateDeliveryNotePDFMock(...args),
+}));
+
+const storageUploadMock = jest
+  .fn()
+  .mockResolvedValue({ url: 'https://cdn/gr.pdf', publicId: 'gr-1', provider: 'local', size: 3 });
+jest.mock('../../src/services/storage', () => ({
+  PDFStorageFactory: { create: () => ({ upload: storageUploadMock, getProviderName: () => 'local' }) },
+}));
+
+const invoiceServiceMocks = {
+  buscarIssuingCompany: jest.fn(),
+  diagnoseP12Certificate: jest.fn(),
+  verifyP12Password: jest.fn(),
+  findWorkingP12Password: jest.fn(),
+};
+jest.mock('../../src/services/invoice.service', () => ({ InvoiceService: invoiceServiceMocks }));
+
+const deliveryNoteStatics = { findOne: jest.fn(), findById: jest.fn() };
+jest.mock('../../src/models/DeliveryNote', () => {
+  class MockDeliveryNote {
+    [key: string]: any;
+    constructor(data: any) {
+      Object.assign(this, data);
+      this._id = 'gr-1';
+    }
+    save = jest.fn().mockResolvedValue(this);
+    static findOne = (...args: any[]) => deliveryNoteStatics.findOne(...args);
+    static findById = (...args: any[]) => deliveryNoteStatics.findById(...args);
+  }
+  return { __esModule: true, default: MockDeliveryNote };
+});
+
+const savedPDFs: any[] = [];
+jest.mock('../../src/models/DeliveryNotePDF', () => {
+  class MockPDF {
+    [key: string]: any;
+    constructor(data: any) {
+      Object.assign(this, data);
+      savedPDFs.push(this);
+    }
+    save = jest.fn().mockResolvedValue(this);
+  }
+  return { __esModule: true, default: MockPDF };
+});
+
+const issuingCompanyStatics = { findOne: jest.fn() };
+jest.mock('../../src/models/IssuingCompany', () => ({
+  __esModule: true,
+  default: { findOne: (...args: any[]) => issuingCompanyStatics.findOne(...args) },
+}));
+
+import { DeliveryNoteService } from '../../src/services/delivery-note.service';
+import { DeliveryNoteRequest } from '../../src/interfaces/delivery-note.interface';
+
+const empresaMock: any = {
+  _id: 'empresa-1',
+  ruc: '1790012345001',
+  razon_social: 'EMPRESA DEMO S.A.',
+  nombre_comercial: 'DEMO',
+  codigo_establecimiento: '001',
+  punto_emision: '001',
+  tipo_ambiente: 1,
+  tipo_emision: 1,
+  direccion_matriz: 'Av. Principal',
+  direccion_establecimiento: 'Av. Principal',
+  obligado_contabilidad: true,
+  certificatePath: '/tmp/cert.p12',
+  certificatePassword: 'test-cert-password',
+};
+
+const requestValido: DeliveryNoteRequest = {
+  infoTributaria: { ruc: empresaMock.ruc, claveAcceso: '', secuencial: '' },
+  infoGuiaRemision: {
+    fechaEmision: '17/05/2025',
+    dirPartida: 'Av. Eloy Alfaro 34',
+    razonSocialTransportista: 'Transportes S.A.',
+    tipoIdentificacionTransportista: '04',
+    rucTransportista: '1796875790001',
+    fechaIniTransporte: '17/05/2025',
+    fechaFinTransporte: '18/05/2025',
+    placa: 'MCL0827',
+  },
+  destinatarios: [
+    {
+      destinatario: {
+        identificacionDestinatario: '1716849140001',
+        razonSocialDestinatario: 'Juan Pérez',
+        dirDestinatario: 'Av. Simón Bolívar S/N',
+        motivoTraslado: 'Venta',
+        detalles: [{ detalle: { descripcion: 'Laptop', cantidad: '10.00' } }],
+      },
+    },
+  ],
+};
+
+describe('DeliveryNoteService', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+    savedPDFs.length = 0;
+    invoiceServiceMocks.buscarIssuingCompany.mockResolvedValue(empresaMock);
+    issuingCompanyStatics.findOne.mockResolvedValue(empresaMock);
+    deliveryNoteStatics.findOne.mockReturnValue({ sort: jest.fn().mockResolvedValue(null) });
+  });
+
+  describe('validarDatosGuiaRemision', () => {
+    it('accepts a complete request', () => {
+      expect(DeliveryNoteService.validarDatosGuiaRemision(requestValido)).toBe(true);
+    });
+
+    it('rejects requests without destinatarios, detalles or transport data', () => {
+      expect(DeliveryNoteService.validarDatosGuiaRemision({ ...requestValido, destinatarios: [] })).toBe(false);
+      expect(
+        DeliveryNoteService.validarDatosGuiaRemision({
+          ...requestValido,
+          destinatarios: [{ destinatario: { ...requestValido.destinatarios[0].destinatario, detalles: [] } }],
+        }),
+      ).toBe(false);
+      expect(
+        DeliveryNoteService.validarDatosGuiaRemision({
+          ...requestValido,
+          infoGuiaRemision: { ...requestValido.infoGuiaRemision, placa: '' },
+        }),
+      ).toBe(false);
+      expect(
+        DeliveryNoteService.validarDatosGuiaRemision({
+          ...requestValido,
+          infoGuiaRemision: { ...requestValido.infoGuiaRemision, rucTransportista: '' },
+        }),
+      ).toBe(false);
+      expect(
+        DeliveryNoteService.validarDatosGuiaRemision({
+          ...requestValido,
+          infoGuiaRemision: { ...requestValido.infoGuiaRemision, dirPartida: '' },
+        }),
+      ).toBe(false);
+      expect(
+        DeliveryNoteService.validarDatosGuiaRemision({
+          ...requestValido,
+          infoGuiaRemision: { ...requestValido.infoGuiaRemision, razonSocialTransportista: '' },
+        }),
+      ).toBe(false);
+    });
+
+    it('rejects an incomplete request through procesarGuiaRemisionCompleta', async () => {
+      await expect(
+        DeliveryNoteService.procesarGuiaRemisionCompleta({ ...requestValido, destinatarios: [] }),
+      ).rejects.toThrow('Datos de guía de remisión inválidos o incompletos');
+    });
+  });
+
+  describe('generarSecuencial', () => {
+    it('increments the latest secuencial', async () => {
+      deliveryNoteStatics.findOne.mockReturnValue({ sort: jest.fn().mockResolvedValue({ secuencial: '000000004' }) });
+
+      await expect(DeliveryNoteService.generarSecuencial(empresaMock.ruc)).resolves.toBe('000000005');
+    });
+
+    it('throws when the empresa does not exist', async () => {
+      issuingCompanyStatics.findOne.mockResolvedValue(null);
+
+      await expect(DeliveryNoteService.generarSecuencial('999')).rejects.toThrow('not found');
+    });
+  });
+
+  describe('procesarGuiaRemisionCompleta', () => {
+    it('fails when the empresa is missing', async () => {
+      invoiceServiceMocks.buscarIssuingCompany.mockResolvedValue(null);
+
+      await expect(DeliveryNoteService.procesarGuiaRemisionCompleta(requestValido)).rejects.toThrow(
+        'Empresa emisora no encontrada',
+      );
+    });
+
+    it('fails on invalid transport dates', async () => {
+      const invalido = {
+        ...requestValido,
+        infoGuiaRemision: { ...requestValido.infoGuiaRemision, fechaFinTransporte: 'mala' },
+      };
+
+      await expect(DeliveryNoteService.procesarGuiaRemisionCompleta(invalido)).rejects.toThrow('Invalid date format');
+    });
+  });
+
+  describe('crearGuiaRemisionCompleta', () => {
+    it('creates the delivery note with an 06 access key and transport data', async () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+      const resultado = await DeliveryNoteService.crearGuiaRemisionCompleta(requestValido);
+
+      expect(resultado.guia_remision.clave_acceso).toHaveLength(49);
+      expect(resultado.guia_remision.clave_acceso.substring(8, 10)).toBe('06');
+      expect(resultado.xml).toContain('<guiaRemision id="comprobante" version="1.1.0">');
+      expect(resultado.guia_remision.placa).toBe('MCL0827');
+      expect(resultado.guia_remision.destinatarios).toHaveLength(1);
+    });
+
+    it('does not fail the creation when the async SRI submission rejects', async () => {
+      const envioSpy = jest.spyOn(DeliveryNoteService, 'procesarEnvioSRI').mockRejectedValue(new Error('sri caído'));
+
+      const resultado = await DeliveryNoteService.crearGuiaRemisionCompleta(requestValido);
+
+      expect(resultado.guia_remision.clave_acceso).toHaveLength(49);
+      expect(envioSpy).toHaveBeenCalled();
+      // give the rejected fire-and-forget promise a tick to settle
+      await new Promise((resolve) => setImmediate(resolve));
+    });
+  });
+
+  describe('procesarEnvioSRI', () => {
+    const doc = () => ({
+      _id: 'gr-1',
+      xml: '<guiaRemision/>',
+      clave_acceso: 'clave',
+      secuencial: '000000001',
+      fecha_emision: new Date(),
+      save: jest.fn().mockResolvedValue(undefined),
+    });
+
+    it('marks ERROR_FIRMA when there is no certificate', async () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+      const guia: any = doc();
+
+      await DeliveryNoteService.procesarEnvioSRI(guia, { ...empresaMock, certificatePath: undefined }, requestValido);
+
+      expect(guia.sri_estado).toBe('ERROR_FIRMA');
+    });
+
+    it('signs with tipoDocumento 06 and completes the RECIBIDA flow', async () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+      invoiceServiceMocks.diagnoseP12Certificate.mockResolvedValue({ isValidP12: true });
+      invoiceServiceMocks.verifyP12Password.mockResolvedValue({ valid: true });
+      enviarComprobanteSRIMock.mockResolvedValue({ estado: 'RECIBIDA' });
+      const programarSpy = jest
+        .spyOn(DeliveryNoteService, 'programarConsultaAutorizacion')
+        .mockImplementation(() => {});
+      const guia: any = doc();
+
+      await DeliveryNoteService.procesarEnvioSRI(guia, empresaMock, requestValido);
+
+      expect(firmarXMLMock).toHaveBeenCalledWith(
+        '<guiaRemision/>',
+        empresaMock.certificatePath,
+        'test-cert-password',
+        '06',
+      );
+      expect(guia.sri_estado).toBe('RECIBIDA');
+      expect(generateDeliveryNotePDFMock).toHaveBeenCalled();
+      expect(programarSpy).toHaveBeenCalledWith('gr-1');
+    });
+
+    it('records the DEVUELTA state and its mensajes without generating a PDF', async () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+      invoiceServiceMocks.diagnoseP12Certificate.mockResolvedValue({ isValidP12: true });
+      invoiceServiceMocks.verifyP12Password.mockResolvedValue({ valid: true });
+      enviarComprobanteSRIMock.mockResolvedValue({
+        estado: 'DEVUELTA',
+        mensajes: { mensaje: { identificador: '35' } },
+      });
+      const guia: any = doc();
+
+      await DeliveryNoteService.procesarEnvioSRI(guia, empresaMock, requestValido);
+
+      expect(guia.sri_estado).toBe('DEVUELTA');
+      expect(guia.sri_mensajes).toEqual({ mensaje: { identificador: '35' } });
+      expect(generateDeliveryNotePDFMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects an invalid P12 as ERROR_FIRMA', async () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+      invoiceServiceMocks.diagnoseP12Certificate.mockResolvedValue({ isValidP12: false, error: 'corrupt' });
+      const guia: any = doc();
+
+      await DeliveryNoteService.procesarEnvioSRI(guia, empresaMock, requestValido);
+
+      expect(guia.sri_estado).toBe('ERROR_FIRMA');
+      expect(guia.sri_mensajes.error).toContain('P12');
+      expect(firmarXMLMock).not.toHaveBeenCalled();
+    });
+
+    it('falls back to an alternative password when verification fails', async () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+      invoiceServiceMocks.diagnoseP12Certificate.mockResolvedValue({ isValidP12: true });
+      invoiceServiceMocks.verifyP12Password.mockResolvedValue({ valid: false, error: 'bad mac' });
+      invoiceServiceMocks.findWorkingP12Password.mockResolvedValue({ password: 'test-fallback-password' });
+      enviarComprobanteSRIMock.mockResolvedValue({ estado: 'RECIBIDA' });
+      jest.spyOn(DeliveryNoteService, 'programarConsultaAutorizacion').mockImplementation(() => {});
+      const guia: any = doc();
+
+      await DeliveryNoteService.procesarEnvioSRI(guia, empresaMock, requestValido);
+
+      expect(firmarXMLMock).toHaveBeenCalledWith(expect.anything(), expect.anything(), 'test-fallback-password', '06');
+    });
+
+    it('marks ERROR_FIRMA when no password works', async () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+      invoiceServiceMocks.diagnoseP12Certificate.mockResolvedValue({ isValidP12: true });
+      invoiceServiceMocks.verifyP12Password.mockResolvedValue({ valid: false, error: 'bad mac' });
+      invoiceServiceMocks.findWorkingP12Password.mockResolvedValue({ password: null });
+      const guia: any = doc();
+
+      await DeliveryNoteService.procesarEnvioSRI(guia, empresaMock, requestValido);
+
+      expect(guia.sri_estado).toBe('ERROR_FIRMA');
+      expect(guia.sri_mensajes.error).toContain('contraseña');
+    });
+
+    it('marks ERROR_FIRMA when the signing itself throws', async () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+      invoiceServiceMocks.diagnoseP12Certificate.mockResolvedValue({ isValidP12: true });
+      invoiceServiceMocks.verifyP12Password.mockResolvedValue({ valid: true });
+      firmarXMLMock.mockRejectedValueOnce(new Error('Error al firmar XML: llave dañada'));
+      const guia: any = doc();
+
+      await DeliveryNoteService.procesarEnvioSRI(guia, empresaMock, requestValido);
+
+      expect(guia.sri_estado).toBe('ERROR_FIRMA');
+      expect(guia.sri_mensajes.error).toContain('firmar');
+    });
+
+    it('marks ERROR_PROCESO when persisting the document fails unexpectedly', async () => {
+      const guia: any = doc();
+      // fs.existsSync throwing escapes the inner try and reaches the outer catch
+      jest.spyOn(fs, 'existsSync').mockImplementation(() => {
+        throw new Error('EIO: disco dañado');
+      });
+
+      await DeliveryNoteService.procesarEnvioSRI(guia, empresaMock, requestValido);
+
+      expect(guia.sri_estado).toBe('ERROR_PROCESO');
+      expect(guia.sri_mensajes.error).toContain('EIO');
+    });
+  });
+
+  describe('consultarAutorizacionSRI', () => {
+    it('updates the delivery note when the SRI authorizes it', async () => {
+      const guia: any = {
+        clave_acceso: 'clave',
+        secuencial: '000000001',
+        save: jest.fn().mockResolvedValue(undefined),
+      };
+      deliveryNoteStatics.findById.mockResolvedValue(guia);
+      autorizarComprobanteSRIMock.mockResolvedValue({ estado: 'AUTORIZADO' });
+
+      const resultado = await DeliveryNoteService.consultarAutorizacionSRI('gr-1');
+
+      expect(resultado?.estado).toBe('AUTORIZADO');
+      expect(guia.estado).toBe('AUTORIZADA');
+      expect(guia.autorizacion_numero).toBe('clave');
+    });
+
+    it('returns null when the delivery note does not exist', async () => {
+      deliveryNoteStatics.findById.mockResolvedValue(null);
+
+      await expect(DeliveryNoteService.consultarAutorizacionSRI('nope')).resolves.toBeNull();
+    });
+  });
+
+  describe('programarConsultaAutorizacion', () => {
+    beforeEach(() => jest.useFakeTimers());
+    afterEach(() => jest.useRealTimers());
+
+    it('stops retrying once the receipt is resolved', async () => {
+      const consultarSpy = jest
+        .spyOn(DeliveryNoteService, 'consultarAutorizacionSRI')
+        .mockResolvedValue({ estado: 'NO AUTORIZADO' } as any);
+
+      DeliveryNoteService.programarConsultaAutorizacion('gr-1', 1, 3, 500);
+      await jest.advanceTimersByTimeAsync(2000);
+
+      expect(consultarSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries while pending, up to the max attempts', async () => {
+      const consultarSpy = jest
+        .spyOn(DeliveryNoteService, 'consultarAutorizacionSRI')
+        .mockResolvedValue({ estado: 'EN PROCESO' } as any);
+
+      DeliveryNoteService.programarConsultaAutorizacion('gr-1', 1, 3, 500);
+      await jest.advanceTimersByTimeAsync(2500);
+
+      expect(consultarSpy).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('generarPDFGuiaRemision', () => {
+    it('generates, uploads and records the PDF', async () => {
+      const guia: any = {
+        _id: 'gr-1',
+        clave_acceso: 'clave',
+        secuencial: '000000001',
+        fecha_emision: new Date(),
+        sri_fecha_respuesta: new Date(),
+      };
+
+      await DeliveryNoteService.generarPDFGuiaRemision(guia, empresaMock, requestValido);
+
+      expect(generateDeliveryNotePDFMock).toHaveBeenCalledWith(
+        expect.objectContaining({ claveAcceso: 'clave', secuencial: '000000001' }),
+      );
+      expect(storageUploadMock).toHaveBeenCalledWith(expect.any(Buffer), 'guia_remision_000000001_clave');
+      expect(savedPDFs[0].estado).toBe('GENERADO');
+      expect(savedPDFs[0].pdf_url).toBe('https://cdn/gr.pdf');
+    });
+
+    it('stores an ERROR record when the PDF generation fails', async () => {
+      generateDeliveryNotePDFMock.mockRejectedValueOnce(new Error('render failed'));
+      const guia: any = { _id: 'gr-1', clave_acceso: 'clave', secuencial: '000000001', fecha_emision: new Date() };
+
+      await DeliveryNoteService.generarPDFGuiaRemision(guia, empresaMock, requestValido);
+
+      expect(savedPDFs[0].estado).toBe('ERROR');
+    });
+  });
+});

--- a/__tests__/services/invoice.service.test.ts
+++ b/__tests__/services/invoice.service.test.ts
@@ -1,0 +1,460 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import forge from 'node-forge';
+
+const firmarXMLMock = jest.fn().mockResolvedValue('<factura>firmada</factura>');
+jest.mock('../../src/utils/firma.utils', () => ({
+  firmarXML: (...args: any[]) => firmarXMLMock(...args),
+}));
+
+const enviarComprobanteSRIMock = jest.fn();
+const autorizarComprobanteSRIMock = jest.fn();
+jest.mock('../../src/utils/sri.utils', () => ({
+  enviarComprobanteSRI: (...args: any[]) => enviarComprobanteSRIMock(...args),
+  autorizarComprobanteSRI: (...args: any[]) => autorizarComprobanteSRIMock(...args),
+}));
+
+const generateInvoicePDFMock = jest.fn().mockResolvedValue(Buffer.from('pdf'));
+jest.mock('../../src/utils/pdf.utils', () => ({
+  generateInvoicePDF: (...args: any[]) => generateInvoicePDFMock(...args),
+}));
+
+const storageUploadMock = jest
+  .fn()
+  .mockResolvedValue({ url: 'https://cdn/f.pdf', publicId: 'f-1', provider: 'local', size: 3 });
+jest.mock('../../src/services/storage', () => ({
+  PDFStorageFactory: { create: () => ({ upload: storageUploadMock, getProviderName: () => 'local' }) },
+}));
+
+// --- Model mocks ---
+const invoiceStatics = { findOne: jest.fn(), findById: jest.fn() };
+const savedInvoices: any[] = [];
+jest.mock('../../src/models/Invoice', () => {
+  class MockInvoice {
+    [key: string]: any;
+    constructor(data: any) {
+      Object.assign(this, data);
+      this._id = 'factura-1';
+      savedInvoices.push(this);
+    }
+    save = jest.fn().mockResolvedValue(this);
+    static findOne = (...args: any[]) => invoiceStatics.findOne(...args);
+    static findById = (...args: any[]) => invoiceStatics.findById(...args);
+  }
+  return { __esModule: true, default: MockInvoice };
+});
+
+const savedDetails: any[] = [];
+jest.mock('../../src/models/InvoiceDetail', () => {
+  class MockDetail {
+    [key: string]: any;
+    constructor(data: any) {
+      Object.assign(this, data);
+      savedDetails.push(this);
+    }
+    save = jest.fn().mockResolvedValue(this);
+  }
+  return { __esModule: true, default: MockDetail };
+});
+
+const savedPDFs: any[] = [];
+jest.mock('../../src/models/InvoicePDF', () => {
+  class MockPDF {
+    [key: string]: any;
+    constructor(data: any) {
+      Object.assign(this, data);
+      savedPDFs.push(this);
+    }
+    save = jest.fn().mockResolvedValue(this);
+  }
+  return { __esModule: true, default: MockPDF };
+});
+
+const identificationTypeStatics = { findOne: jest.fn() };
+jest.mock('../../src/models/IdentificationType', () => ({
+  __esModule: true,
+  default: { findOne: (...args: any[]) => identificationTypeStatics.findOne(...args) },
+}));
+
+const issuingCompanyStatics = { findOne: jest.fn() };
+jest.mock('../../src/models/IssuingCompany', () => ({
+  __esModule: true,
+  default: { findOne: (...args: any[]) => issuingCompanyStatics.findOne(...args) },
+}));
+
+const clientStatics = { findOne: jest.fn() };
+jest.mock('../../src/models/Client', () => ({
+  __esModule: true,
+  default: { findOne: (...args: any[]) => clientStatics.findOne(...args) },
+}));
+
+const productStatics = { findOne: jest.fn() };
+jest.mock('../../src/models/Product', () => ({
+  __esModule: true,
+  default: { findOne: (...args: any[]) => productStatics.findOne(...args) },
+}));
+
+import { InvoiceService } from '../../src/services/invoice.service';
+import { InvoiceRequest } from '../../src/interfaces/invoice.interface';
+
+const P12_PASSWORD = 'test-p12-password';
+let p12Path: string;
+let p12Base64: string;
+
+function crearP12(): void {
+  const keys = forge.pki.rsa.generateKeyPair(2048);
+  const cert = forge.pki.createCertificate();
+  cert.publicKey = keys.publicKey;
+  cert.serialNumber = '01';
+  cert.validity.notBefore = new Date();
+  cert.validity.notAfter = new Date();
+  cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 1);
+  const attrs = [
+    { shortName: 'CN', value: 'JUAN PEREZ' },
+    { shortName: 'C', value: 'EC' },
+  ];
+  cert.setSubject(attrs);
+  cert.setIssuer(attrs);
+  cert.sign(keys.privateKey, forge.md.sha256.create());
+
+  const p12Asn1 = forge.pkcs12.toPkcs12Asn1(keys.privateKey, cert, P12_PASSWORD);
+  const buffer = Buffer.from(forge.asn1.toDer(p12Asn1).getBytes(), 'binary');
+  p12Path = path.join(os.tmpdir(), `invoice-svc-test-${Date.now()}.p12`);
+  fs.writeFileSync(p12Path, buffer);
+  p12Base64 = buffer.toString('base64');
+}
+
+const empresaBase = () => ({
+  _id: 'empresa-1',
+  ruc: '1790012345001',
+  razon_social: 'EMPRESA DEMO S.A.',
+  nombre_comercial: 'DEMO',
+  codigo_establecimiento: '001',
+  punto_emision: '001',
+  tipo_ambiente: 1,
+  tipo_emision: 1,
+  direccion_matriz: 'Av. Principal',
+  direccion_establecimiento: 'Av. Principal',
+  obligado_contabilidad: true,
+  toObject() {
+    return { ...this };
+  },
+});
+
+const clienteMock: any = { _id: 'cliente-1', razon_social: 'CLIENTE', identificacion: '0106079783' };
+const productoMock: any = { _id: 'producto-1', codigo: 'P001', tiene_iva: true, precio_unitario: 100 };
+
+const requestValido: InvoiceRequest = {
+  infoTributaria: { ruc: '1790012345001', claveAcceso: '', secuencial: '' },
+  infoFactura: {
+    fechaEmision: '17/05/2025',
+    tipoIdentificacionComprador: '05',
+    identificacionComprador: clienteMock.identificacion,
+    razonSocialComprador: 'CLIENTE',
+    totalSinImpuestos: '100.00',
+    importeTotal: '115.00',
+  },
+  detalles: [
+    {
+      detalle: {
+        codigoPrincipal: 'P001',
+        descripcion: 'Laptop',
+        cantidad: '1.00',
+        precioUnitario: '100.00',
+        precioTotalSinImpuesto: '100.00',
+        impuestos: [
+          {
+            impuesto: { codigo: '2', codigoPorcentaje: '4', tarifa: '15.00', baseImponible: '100.00', valor: '15.00' },
+          },
+        ],
+      },
+    },
+  ],
+};
+
+beforeAll(() => crearP12());
+afterAll(() => {
+  if (fs.existsSync(p12Path)) fs.unlinkSync(p12Path);
+});
+
+describe('InvoiceService', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+    savedInvoices.length = 0;
+    savedDetails.length = 0;
+    savedPDFs.length = 0;
+    identificationTypeStatics.findOne.mockResolvedValue({ codigo: '05' });
+    issuingCompanyStatics.findOne.mockResolvedValue(empresaBase());
+    clientStatics.findOne.mockResolvedValue(clienteMock);
+    productStatics.findOne.mockResolvedValue(productoMock);
+    invoiceStatics.findOne.mockReturnValue({ sort: jest.fn().mockResolvedValue(null) });
+  });
+
+  describe('validarDatosFactura', () => {
+    it('accepts complete data and rejects incomplete data', () => {
+      expect(InvoiceService.validarDatosFactura(requestValido)).toBe(true);
+      expect(InvoiceService.validarDatosFactura({ ...requestValido, detalles: undefined } as any)).toBe(false);
+    });
+  });
+
+  describe('generarSecuencial', () => {
+    it('starts at 000000001 and increments existing sequences', async () => {
+      await expect(InvoiceService.generarSecuencial('1790012345001')).resolves.toBe('000000001');
+
+      invoiceStatics.findOne.mockReturnValue({ sort: jest.fn().mockResolvedValue({ secuencial: '000000007' }) });
+      await expect(InvoiceService.generarSecuencial('1790012345001')).resolves.toBe('000000008');
+    });
+
+    it('throws when the empresa does not exist', async () => {
+      issuingCompanyStatics.findOne.mockResolvedValue(null);
+
+      await expect(InvoiceService.generarSecuencial('999')).rejects.toThrow('not found');
+    });
+  });
+
+  describe('buscarIssuingCompany', () => {
+    it('returns the empresa without certificate data when none is stored', async () => {
+      const empresa = await InvoiceService.buscarIssuingCompany('1790012345001');
+
+      expect(empresa?.ruc).toBe('1790012345001');
+      expect(empresa?.certificatePath).toBeUndefined();
+    });
+
+    it('materializes the base64 certificate into a temp P12 file', async () => {
+      issuingCompanyStatics.findOne.mockResolvedValue({
+        ...empresaBase(),
+        certificate: p12Base64,
+        certificate_password: P12_PASSWORD,
+      });
+
+      const empresa = await InvoiceService.buscarIssuingCompany('1790012345001');
+
+      expect(empresa?.certificatePath).toBeDefined();
+      expect(fs.existsSync(empresa!.certificatePath!)).toBe(true);
+      expect(empresa?.certificatePassword).toBe(P12_PASSWORD);
+    });
+
+    it('falls back to the raw password when decryption fails', async () => {
+      issuingCompanyStatics.findOne.mockResolvedValue({
+        ...empresaBase(),
+        certificate: p12Base64,
+        certificate_password: 'test:fake-encrypted-format',
+      });
+
+      const empresa = await InvoiceService.buscarIssuingCompany('1790012345001');
+
+      expect(empresa?.certificatePassword).toBe('test:fake-encrypted-format');
+    });
+
+    it('returns null when the empresa does not exist', async () => {
+      issuingCompanyStatics.findOne.mockResolvedValue(null);
+
+      await expect(InvoiceService.buscarIssuingCompany('999')).resolves.toBeNull();
+    });
+  });
+
+  describe('buscarProducts', () => {
+    it('throws when a product is missing', async () => {
+      productStatics.findOne.mockResolvedValue(null);
+
+      await expect(InvoiceService.buscarProducts(requestValido.detalles)).rejects.toThrow('Product not found: P001');
+    });
+  });
+
+  describe('procesarFacturaCompleta', () => {
+    it.each([
+      [
+        'identification type',
+        () => identificationTypeStatics.findOne.mockResolvedValue(null),
+        'Identification type not found',
+      ],
+      ['empresa', () => issuingCompanyStatics.findOne.mockResolvedValue(null), 'Empresa emisora no encontrada'],
+      ['client', () => clientStatics.findOne.mockResolvedValue(null), 'Client not found'],
+    ])('fails when the %s is missing', async (_n, arrange, mensaje) => {
+      arrange();
+
+      await expect(InvoiceService.procesarFacturaCompleta(requestValido)).rejects.toThrow(mensaje);
+    });
+
+    it('fails on invalid dates', async () => {
+      const invalido = { ...requestValido, infoFactura: { ...requestValido.infoFactura, fechaEmision: 'mala' } };
+
+      await expect(InvoiceService.procesarFacturaCompleta(invalido)).rejects.toThrow('Invalid date format');
+    });
+  });
+
+  describe('crearFacturaCompleta', () => {
+    it('creates the invoice with an 01 access key, XML, totals and details', async () => {
+      const resultado = await InvoiceService.crearFacturaCompleta(requestValido);
+
+      expect(resultado.factura.clave_acceso).toHaveLength(49);
+      expect(resultado.factura.clave_acceso.substring(8, 10)).toBe('01');
+      expect(resultado.xml).toContain('<factura id="comprobante" version="1.0.0">');
+      expect(resultado.factura.total_iva).toBe(15);
+      expect(resultado.factura.total_con_impuestos).toBe(115);
+      // The async SRI submission may already have run (no certificate in this test)
+      expect(['PENDIENTE', 'ERROR_FIRMA']).toContain(resultado.factura.sri_estado);
+      expect(resultado.detalles).toHaveLength(1);
+    });
+  });
+
+  describe('P12 helpers (real certificate)', () => {
+    it('verifyP12Password accepts the right password and rejects a wrong one', async () => {
+      await expect(InvoiceService.verifyP12Password(p12Path, P12_PASSWORD)).resolves.toEqual({ valid: true });
+
+      const wrong = await InvoiceService.verifyP12Password(p12Path, 'incorrecta');
+      expect(wrong.valid).toBe(false);
+      expect(wrong.error).toBeDefined();
+    });
+
+    it('findWorkingP12Password finds the original password and fails when none works', async () => {
+      await expect(InvoiceService.findWorkingP12Password(p12Path, P12_PASSWORD)).resolves.toEqual({
+        password: P12_PASSWORD,
+      });
+
+      const ninguna = await InvoiceService.findWorkingP12Password(p12Path, 'incorrecta');
+      expect(ninguna.password).toBeNull();
+    });
+
+    it('convertP12ToPem produces a combined PEM with key and certificate', async () => {
+      const pemPath = await InvoiceService.convertP12ToPem(p12Path, P12_PASSWORD);
+
+      const contenido = fs.readFileSync(pemPath, 'utf8');
+      expect(contenido).toContain('PRIVATE KEY');
+      expect(contenido).toContain('BEGIN CERTIFICATE');
+      fs.unlinkSync(pemPath);
+    });
+
+    it('convertP12ToPem throws a password error for a wrong password', async () => {
+      await expect(InvoiceService.convertP12ToPem(p12Path, 'incorrecta')).rejects.toThrow('contraseña');
+    });
+
+    it('diagnoseP12Certificate reports a healthy certificate', async () => {
+      const diagnosis = await InvoiceService.diagnoseP12Certificate(p12Path, P12_PASSWORD);
+
+      expect(diagnosis.fileExists).toBe(true);
+      expect(diagnosis.isValidP12).toBe(true);
+      expect(diagnosis.passwordWorks).toBe(true);
+      expect(diagnosis.certificateInfo?.subject).toContain('JUAN PEREZ');
+    });
+
+    it('diagnoseP12Certificate reports missing files and wrong passwords', async () => {
+      const missing = await InvoiceService.diagnoseP12Certificate('/tmp/no-existe.p12', 'x');
+      expect(missing.fileExists).toBe(false);
+
+      const badPass = await InvoiceService.diagnoseP12Certificate(p12Path, 'incorrecta');
+      expect(badPass.passwordWorks).toBe(false);
+      expect(badPass.error).toContain('contraseña');
+    });
+  });
+
+  describe('procesarEnvioSRI', () => {
+    const facturaDoc = () => ({
+      _id: 'factura-1',
+      xml: '<factura/>',
+      clave_acceso: 'clave',
+      secuencial: '000000001',
+      fecha_emision: new Date(),
+      save: jest.fn().mockResolvedValue(undefined),
+    });
+
+    it('marks ERROR_FIRMA when there is no certificate', async () => {
+      const factura: any = facturaDoc();
+
+      await InvoiceService.procesarEnvioSRI(factura, { certificatePath: undefined }, clienteMock, [], requestValido);
+
+      expect(factura.sri_estado).toBe('ERROR_FIRMA');
+    });
+
+    it('signs with the real P12, sends, generates the PDF and schedules authorization on RECIBIDA', async () => {
+      enviarComprobanteSRIMock.mockResolvedValue({ estado: 'RECIBIDA' });
+      const programarSpy = jest.spyOn(InvoiceService, 'programarConsultaAutorizacion').mockImplementation(() => {});
+      const factura: any = facturaDoc();
+      const empresa = { ...empresaBase(), certificatePath: p12Path, certificatePassword: P12_PASSWORD };
+
+      await InvoiceService.procesarEnvioSRI(factura, empresa, clienteMock, [productoMock], requestValido);
+
+      expect(firmarXMLMock).toHaveBeenCalledWith('<factura/>', p12Path, P12_PASSWORD, '01');
+      expect(factura.sri_estado).toBe('RECIBIDA');
+      expect(generateInvoicePDFMock).toHaveBeenCalled();
+      expect(savedPDFs[0].estado).toBe('GENERADO');
+      expect(programarSpy).toHaveBeenCalledWith('factura-1');
+    });
+
+    it('records the DEVUELTA state without generating a PDF', async () => {
+      enviarComprobanteSRIMock.mockResolvedValue({
+        estado: 'DEVUELTA',
+        mensajes: { mensaje: { identificador: '35' } },
+      });
+      const factura: any = facturaDoc();
+      const empresa = { ...empresaBase(), certificatePath: p12Path, certificatePassword: P12_PASSWORD };
+
+      await InvoiceService.procesarEnvioSRI(factura, empresa, clienteMock, [], requestValido);
+
+      expect(factura.sri_estado).toBe('DEVUELTA');
+      expect(generateInvoicePDFMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('consultarAutorizacionSRI', () => {
+    it('updates the invoice when the SRI authorizes it', async () => {
+      const factura: any = {
+        clave_acceso: 'clave',
+        secuencial: '000000001',
+        save: jest.fn().mockResolvedValue(undefined),
+      };
+      invoiceStatics.findById.mockResolvedValue(factura);
+      autorizarComprobanteSRIMock.mockResolvedValue({
+        estado: 'AUTORIZADO',
+        numeroAutorizacion: 'clave',
+        fechaAutorizacion: '2025-05-17T12:00:00-05:00',
+      });
+
+      const resultado = await InvoiceService.consultarAutorizacionSRI('factura-1');
+
+      expect(resultado?.estado).toBe('AUTORIZADO');
+      expect(factura.estado).toBe('AUTORIZADA');
+      expect(factura.autorizacion_numero).toBe('clave');
+    });
+
+    it('returns null when the invoice does not exist', async () => {
+      invoiceStatics.findById.mockResolvedValue(null);
+
+      await expect(InvoiceService.consultarAutorizacionSRI('nope')).resolves.toBeNull();
+    });
+  });
+
+  describe('programarConsultaAutorizacion', () => {
+    beforeEach(() => jest.useFakeTimers());
+    afterEach(() => jest.useRealTimers());
+
+    it('retries while pending, up to the max attempts', async () => {
+      const consultarSpy = jest
+        .spyOn(InvoiceService, 'consultarAutorizacionSRI')
+        .mockResolvedValue({ estado: 'EN PROCESO' } as any);
+
+      InvoiceService.programarConsultaAutorizacion('factura-1', 1, 3, 500);
+      await jest.advanceTimersByTimeAsync(2500);
+
+      expect(consultarSpy).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('generarPDFFactura', () => {
+    it('stores an ERROR record when the PDF generation fails', async () => {
+      generateInvoicePDFMock.mockRejectedValueOnce(new Error('render failed'));
+      const factura: any = {
+        _id: 'factura-1',
+        clave_acceso: 'clave',
+        secuencial: '000000001',
+        fecha_emision: new Date(),
+      };
+
+      await InvoiceService.generarPDFFactura(factura, empresaBase() as any, clienteMock, [], requestValido);
+
+      expect(savedPDFs[0].estado).toBe('ERROR');
+    });
+  });
+});

--- a/__tests__/services/localStorage.errors.test.ts
+++ b/__tests__/services/localStorage.errors.test.ts
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import { LocalPDFStorage } from '../../src/services/storage/local.storage';
+
+/**
+ * Error-path coverage for LocalPDFStorage: filesystem failures must be
+ * reported cleanly instead of crashing the invoicing flow.
+ */
+describe('LocalPDFStorage error handling', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('throws a descriptive error when the storage directory cannot be created', () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+    jest.spyOn(fs, 'mkdirSync').mockImplementation(() => {
+      throw new Error('EACCES: permission denied');
+    });
+
+    expect(() => new LocalPDFStorage()).toThrow('No se pudo crear el directorio de almacenamiento');
+  });
+
+  it('throws a descriptive error when writing the PDF fails', async () => {
+    const storage = new LocalPDFStorage();
+    jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {
+      throw new Error('ENOSPC: no space left on device');
+    });
+
+    await expect(storage.upload(Buffer.from('pdf'), 'factura_test')).rejects.toThrow('Error guardando PDF localmente');
+  });
+
+  it('returns false when deleting a PDF fails', async () => {
+    const storage = new LocalPDFStorage();
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs, 'unlinkSync').mockImplementation(() => {
+      throw new Error('EBUSY: resource busy');
+    });
+
+    await expect(storage.delete('factura_test.pdf')).resolves.toBe(false);
+  });
+
+  it('reports exists false when reading file info fails', () => {
+    const storage = new LocalPDFStorage();
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs, 'statSync').mockImplementation(() => {
+      throw new Error('EIO: i/o error');
+    });
+
+    expect(storage.getFileInfo('factura_test.pdf')).toEqual({ exists: false });
+  });
+});

--- a/__tests__/services/withholding.service.test.ts
+++ b/__tests__/services/withholding.service.test.ts
@@ -218,6 +218,31 @@ describe('WithholdingService', () => {
       expect(resultado.retencion.total_retenido).toBeCloseTo(12.25);
       expect(resultado.retencion.periodo_fiscal).toBe('05/2025');
     });
+
+    it('always emits the mandatory <parteRel> tag (default NO) before razonSocialSujetoRetenido', async () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+      const resultado = await WithholdingService.crearRetencionCompleta(requestValido);
+
+      // ATS 2.0.0 schema: {tipoSujetoRetenido?, parteRel} must precede razonSocialSujetoRetenido,
+      // otherwise SRI rejects with error 35 (ARCHIVO NO CUMPLE ESTRUCTURA XML)
+      expect(resultado.xml).toContain('<parteRel>NO</parteRel>');
+      expect(resultado.xml.indexOf('<parteRel>')).toBeLessThan(resultado.xml.indexOf('<razonSocialSujetoRetenido>'));
+    });
+
+    it('respects an explicit parteRel value and emits tipoSujetoRetenido when provided', async () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+      const request = JSON.parse(JSON.stringify(requestValido)) as WithholdingRequest;
+      request.infoCompRetencion.parteRel = 'SI';
+      request.infoCompRetencion.tipoSujetoRetenido = '01';
+
+      const resultado = await WithholdingService.crearRetencionCompleta(request);
+
+      expect(resultado.xml).toContain('<parteRel>SI</parteRel>');
+      expect(resultado.xml).toContain('<tipoSujetoRetenido>01</tipoSujetoRetenido>');
+      expect(resultado.xml.indexOf('<tipoSujetoRetenido>')).toBeLessThan(resultado.xml.indexOf('<parteRel>'));
+    });
   });
 
   describe('procesarEnvioSRI', () => {

--- a/__tests__/services/withholding.service.test.ts
+++ b/__tests__/services/withholding.service.test.ts
@@ -1,0 +1,329 @@
+import fs from 'fs';
+
+const firmarXMLMock = jest.fn().mockResolvedValue('<comprobanteRetencion>firmada</comprobanteRetencion>');
+jest.mock('../../src/utils/firma.utils', () => ({
+  firmarXML: (...args: any[]) => firmarXMLMock(...args),
+}));
+
+const enviarComprobanteSRIMock = jest.fn();
+const autorizarComprobanteSRIMock = jest.fn();
+jest.mock('../../src/utils/sri.utils', () => ({
+  enviarComprobanteSRI: (...args: any[]) => enviarComprobanteSRIMock(...args),
+  autorizarComprobanteSRI: (...args: any[]) => autorizarComprobanteSRIMock(...args),
+}));
+
+const generateWithholdingPDFMock = jest.fn().mockResolvedValue(Buffer.from('pdf'));
+jest.mock('../../src/utils/pdf.utils', () => ({
+  generateWithholdingPDF: (...args: any[]) => generateWithholdingPDFMock(...args),
+}));
+
+const storageUploadMock = jest
+  .fn()
+  .mockResolvedValue({ url: 'https://cdn/ret.pdf', publicId: 'ret-1', provider: 'local', size: 3 });
+jest.mock('../../src/services/storage', () => ({
+  PDFStorageFactory: { create: () => ({ upload: storageUploadMock, getProviderName: () => 'local' }) },
+}));
+
+const invoiceServiceMocks = {
+  buscarIssuingCompany: jest.fn(),
+  diagnoseP12Certificate: jest.fn(),
+  verifyP12Password: jest.fn(),
+  findWorkingP12Password: jest.fn(),
+};
+jest.mock('../../src/services/invoice.service', () => ({ InvoiceService: invoiceServiceMocks }));
+
+const withholdingStatics = { findOne: jest.fn(), findById: jest.fn() };
+jest.mock('../../src/models/Withholding', () => {
+  class MockWithholding {
+    [key: string]: any;
+    constructor(data: any) {
+      Object.assign(this, data);
+      this._id = 'ret-1';
+    }
+    save = jest.fn().mockResolvedValue(this);
+    static findOne = (...args: any[]) => withholdingStatics.findOne(...args);
+    static findById = (...args: any[]) => withholdingStatics.findById(...args);
+  }
+  return { __esModule: true, default: MockWithholding };
+});
+
+const savedPDFs: any[] = [];
+jest.mock('../../src/models/WithholdingPDF', () => {
+  class MockPDF {
+    [key: string]: any;
+    constructor(data: any) {
+      Object.assign(this, data);
+      savedPDFs.push(this);
+    }
+    save = jest.fn().mockResolvedValue(this);
+  }
+  return { __esModule: true, default: MockPDF };
+});
+
+const issuingCompanyStatics = { findOne: jest.fn() };
+jest.mock('../../src/models/IssuingCompany', () => ({
+  __esModule: true,
+  default: { findOne: (...args: any[]) => issuingCompanyStatics.findOne(...args) },
+}));
+
+import { WithholdingService } from '../../src/services/withholding.service';
+import { WithholdingRequest } from '../../src/interfaces/withholding.interface';
+
+const empresaMock: any = {
+  _id: 'empresa-1',
+  ruc: '1790012345001',
+  razon_social: 'EMPRESA DEMO S.A.',
+  nombre_comercial: 'DEMO',
+  codigo_establecimiento: '001',
+  punto_emision: '001',
+  tipo_ambiente: 1,
+  tipo_emision: 1,
+  direccion_matriz: 'Av. Principal',
+  direccion_establecimiento: 'Av. Principal',
+  obligado_contabilidad: true,
+  certificatePath: '/tmp/cert.p12',
+  certificatePassword: 'test-cert-password',
+};
+
+const requestValido: WithholdingRequest = {
+  infoTributaria: { ruc: empresaMock.ruc, claveAcceso: '', secuencial: '' },
+  infoCompRetencion: {
+    fechaEmision: '17/05/2025',
+    tipoIdentificacionSujetoRetenido: '04',
+    razonSocialSujetoRetenido: 'Proveedor S.A.',
+    identificacionSujetoRetenido: '1713328506001',
+    periodoFiscal: '05/2025',
+  },
+  docsSustento: [
+    {
+      docSustento: {
+        codSustento: '01',
+        codDocSustento: '01',
+        numDocSustento: '001001000000123',
+        fechaEmisionDocSustento: '10/05/2025',
+        pagoLocExt: '01',
+        totalSinImpuestos: '100.00',
+        importeTotal: '115.00',
+        impuestosDocSustento: [
+          {
+            impuestoDocSustento: {
+              codImpuestoDocSustento: '2',
+              codigoPorcentaje: '4',
+              baseImponible: '100.00',
+              tarifa: '15',
+              valorImpuesto: '15.00',
+            },
+          },
+        ],
+        retenciones: [
+          {
+            retencion: {
+              codigo: '1',
+              codigoRetencion: '312',
+              baseImponible: '100.00',
+              porcentajeRetener: '1.75',
+              valorRetenido: '1.75',
+            },
+          },
+          {
+            retencion: {
+              codigo: '2',
+              codigoRetencion: '3',
+              baseImponible: '15.00',
+              porcentajeRetener: '70',
+              valorRetenido: '10.50',
+            },
+          },
+        ],
+        pagos: [{ pago: { formaPago: '01', total: '115.00' } }],
+      },
+    },
+  ],
+};
+
+describe('WithholdingService', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+    savedPDFs.length = 0;
+    invoiceServiceMocks.buscarIssuingCompany.mockResolvedValue(empresaMock);
+    issuingCompanyStatics.findOne.mockResolvedValue(empresaMock);
+    withholdingStatics.findOne.mockReturnValue({ sort: jest.fn().mockResolvedValue(null) });
+  });
+
+  describe('validarDatosRetencion', () => {
+    it('accepts a complete request', () => {
+      expect(WithholdingService.validarDatosRetencion(requestValido)).toBe(true);
+    });
+
+    it('rejects requests without docsSustento, retenciones, impuestos or pagos', () => {
+      expect(WithholdingService.validarDatosRetencion({ ...requestValido, docsSustento: [] })).toBe(false);
+
+      const sinRetenciones = JSON.parse(JSON.stringify(requestValido)) as WithholdingRequest;
+      sinRetenciones.docsSustento[0].docSustento.retenciones = [];
+      expect(WithholdingService.validarDatosRetencion(sinRetenciones)).toBe(false);
+
+      const sinImpuestos = JSON.parse(JSON.stringify(requestValido)) as WithholdingRequest;
+      sinImpuestos.docsSustento[0].docSustento.impuestosDocSustento = [];
+      expect(WithholdingService.validarDatosRetencion(sinImpuestos)).toBe(false);
+
+      const sinPagos = JSON.parse(JSON.stringify(requestValido)) as WithholdingRequest;
+      sinPagos.docsSustento[0].docSustento.pagos = [];
+      expect(WithholdingService.validarDatosRetencion(sinPagos)).toBe(false);
+    });
+  });
+
+  describe('generarSecuencial', () => {
+    it('increments the latest secuencial', async () => {
+      withholdingStatics.findOne.mockReturnValue({ sort: jest.fn().mockResolvedValue({ secuencial: '000000099' }) });
+
+      await expect(WithholdingService.generarSecuencial(empresaMock.ruc)).resolves.toBe('000000100');
+    });
+
+    it('throws when the empresa does not exist', async () => {
+      issuingCompanyStatics.findOne.mockResolvedValue(null);
+
+      await expect(WithholdingService.generarSecuencial('999')).rejects.toThrow('not found');
+    });
+  });
+
+  describe('procesarRetencionCompleta', () => {
+    it('fails when the empresa is missing', async () => {
+      invoiceServiceMocks.buscarIssuingCompany.mockResolvedValue(null);
+
+      await expect(WithholdingService.procesarRetencionCompleta(requestValido)).rejects.toThrow(
+        'Empresa emisora no encontrada',
+      );
+    });
+
+    it('fails on invalid dates', async () => {
+      const invalido = {
+        ...requestValido,
+        infoCompRetencion: { ...requestValido.infoCompRetencion, fechaEmision: 'mala' },
+      };
+
+      await expect(WithholdingService.procesarRetencionCompleta(invalido)).rejects.toThrow('Invalid date format');
+    });
+  });
+
+  describe('crearRetencionCompleta', () => {
+    it('creates the withholding with an 07 access key and the computed total retenido', async () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+      const resultado = await WithholdingService.crearRetencionCompleta(requestValido);
+
+      expect(resultado.retencion.clave_acceso).toHaveLength(49);
+      expect(resultado.retencion.clave_acceso.substring(8, 10)).toBe('07');
+      expect(resultado.xml).toContain('<comprobanteRetencion id="comprobante" version="2.0.0">');
+      expect(resultado.retencion.total_retenido).toBeCloseTo(12.25);
+      expect(resultado.retencion.periodo_fiscal).toBe('05/2025');
+    });
+  });
+
+  describe('procesarEnvioSRI', () => {
+    const doc = () => ({
+      _id: 'ret-1',
+      xml: '<comprobanteRetencion/>',
+      clave_acceso: 'clave',
+      secuencial: '000000001',
+      fecha_emision: new Date(),
+      save: jest.fn().mockResolvedValue(undefined),
+    });
+
+    it('marks ERROR_FIRMA when there is no certificate', async () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+      const ret: any = doc();
+
+      await WithholdingService.procesarEnvioSRI(ret, { ...empresaMock, certificatePath: undefined }, requestValido);
+
+      expect(ret.sri_estado).toBe('ERROR_FIRMA');
+    });
+
+    it('signs with tipoDocumento 07 and completes the RECIBIDA flow', async () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+      invoiceServiceMocks.diagnoseP12Certificate.mockResolvedValue({ isValidP12: true });
+      invoiceServiceMocks.verifyP12Password.mockResolvedValue({ valid: true });
+      enviarComprobanteSRIMock.mockResolvedValue({ estado: 'RECIBIDA' });
+      const programarSpy = jest.spyOn(WithholdingService, 'programarConsultaAutorizacion').mockImplementation(() => {});
+      const ret: any = doc();
+
+      await WithholdingService.procesarEnvioSRI(ret, empresaMock, requestValido);
+
+      expect(firmarXMLMock).toHaveBeenCalledWith(
+        '<comprobanteRetencion/>',
+        empresaMock.certificatePath,
+        'test-cert-password',
+        '07',
+      );
+      expect(ret.sri_estado).toBe('RECIBIDA');
+      expect(generateWithholdingPDFMock).toHaveBeenCalled();
+      expect(savedPDFs[0].estado).toBe('GENERADO');
+      expect(programarSpy).toHaveBeenCalledWith('ret-1');
+    });
+
+    it('marks ERROR_PROCESO when saving fails outside the signing block', async () => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+      invoiceServiceMocks.diagnoseP12Certificate.mockResolvedValue({ isValidP12: true });
+      invoiceServiceMocks.verifyP12Password.mockResolvedValue({ valid: true });
+      enviarComprobanteSRIMock.mockResolvedValue({ estado: 'RECIBIDA' });
+      const ret: any = doc();
+      // First save (xml_firmado) throws → captured by the outer catch
+      ret.save.mockRejectedValueOnce(new Error('mongo down')).mockResolvedValue(undefined);
+
+      await WithholdingService.procesarEnvioSRI(ret, empresaMock, requestValido);
+
+      expect(['ERROR_FIRMA', 'ERROR_PROCESO']).toContain(ret.sri_estado);
+    });
+  });
+
+  describe('consultarAutorizacionSRI', () => {
+    it('updates the withholding when the SRI authorizes it', async () => {
+      const ret: any = { clave_acceso: 'clave', secuencial: '000000001', save: jest.fn().mockResolvedValue(undefined) };
+      withholdingStatics.findById.mockResolvedValue(ret);
+      autorizarComprobanteSRIMock.mockResolvedValue({
+        estado: 'AUTORIZADO',
+        numeroAutorizacion: 'clave',
+        fechaAutorizacion: '2025-05-17T12:00:00-05:00',
+      });
+
+      const resultado = await WithholdingService.consultarAutorizacionSRI('ret-1');
+
+      expect(resultado?.estado).toBe('AUTORIZADO');
+      expect(ret.estado).toBe('AUTORIZADA');
+      expect(ret.fecha_autorizacion).toBeInstanceOf(Date);
+    });
+
+    it('returns null when the withholding does not exist', async () => {
+      withholdingStatics.findById.mockResolvedValue(null);
+
+      await expect(WithholdingService.consultarAutorizacionSRI('nope')).resolves.toBeNull();
+    });
+  });
+
+  describe('programarConsultaAutorizacion', () => {
+    beforeEach(() => jest.useFakeTimers());
+    afterEach(() => jest.useRealTimers());
+
+    it('retries while pending, up to the max attempts', async () => {
+      const consultarSpy = jest
+        .spyOn(WithholdingService, 'consultarAutorizacionSRI')
+        .mockResolvedValue({ estado: 'EN PROCESO' } as any);
+
+      WithholdingService.programarConsultaAutorizacion('ret-1', 1, 3, 500);
+      await jest.advanceTimersByTimeAsync(2500);
+
+      expect(consultarSpy).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('generarPDFRetencion', () => {
+    it('stores an ERROR record when the PDF generation fails', async () => {
+      generateWithholdingPDFMock.mockRejectedValueOnce(new Error('render failed'));
+      const ret: any = { _id: 'ret-1', clave_acceso: 'clave', secuencial: '000000001', fecha_emision: new Date() };
+
+      await WithholdingService.generarPDFRetencion(ret, empresaMock, requestValido);
+
+      expect(savedPDFs[0].estado).toBe('ERROR');
+    });
+  });
+});

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -1,10 +1,13 @@
+import crypto from 'crypto';
+
 // Global test setup
 jest.setTimeout(30000);
 
 // Mock environment variables for tests
 process.env.NODE_ENV = 'test';
 process.env.JWT_SECRET = 'test_jwt_secret_key_for_testing';
-process.env.ENCRYPTION_KEY = 'REDACTED_TEST_ENCRYPTION_KEY_ROTATED'; // valor secreto no valido, solo para test
+// Generado en tiempo de ejecución (no hardcodeado) para evitar falsos positivos de escaneo de secretos
+process.env.ENCRYPTION_KEY = crypto.randomBytes(32).toString('hex');
 process.env.MONGO_URI = 'mongodb://localhost:27017/veronica_test';
 
 // Global mocks for CI environment

--- a/__tests__/setup.ts
+++ b/__tests__/setup.ts
@@ -4,6 +4,7 @@ jest.setTimeout(30000);
 // Mock environment variables for tests
 process.env.NODE_ENV = 'test';
 process.env.JWT_SECRET = 'test_jwt_secret_key_for_testing';
+process.env.ENCRYPTION_KEY = 'REDACTED_TEST_ENCRYPTION_KEY_ROTATED'; // valor secreto no valido, solo para test
 process.env.MONGO_URI = 'mongodb://localhost:27017/veronica_test';
 
 // Global mocks for CI environment

--- a/__tests__/utils/creditNote.utils.test.ts
+++ b/__tests__/utils/creditNote.utils.test.ts
@@ -1,0 +1,147 @@
+import { generarXMLNotaCredito, obtenerConfiguracionIVA } from '../../src/utils/xml.utils';
+import { generarClaveAcceso, obtenerDigitoVerificador } from '../../src/utils/invoice.utils';
+import { CreditNoteRequest } from '../../src/interfaces/credit-note.interface';
+
+const empresaMock: any = {
+  tipo_ambiente: 1,
+  tipo_emision: 1,
+  razon_social: 'EMPRESA DEMO S.A.',
+  nombre_comercial: 'DEMO',
+  ruc: '1790012345001',
+  codigo_establecimiento: '001',
+  punto_emision: '001',
+  direccion_matriz: 'Av. Principal 123',
+  direccion_establecimiento: 'Av. Principal 123',
+  obligado_contabilidad: true,
+};
+
+const clienteMock: any = {
+  razon_social: 'CLIENTE DE PRUEBA',
+  identificacion: '0106079783',
+  email: 'cliente@test.com',
+  telefono: '0999999999',
+};
+
+const notaCreditoMock: CreditNoteRequest = {
+  infoTributaria: { ruc: '1790012345001', claveAcceso: '', secuencial: '' },
+  infoNotaCredito: {
+    fechaEmision: '17/05/2025',
+    tipoIdentificacionComprador: '05',
+    identificacionComprador: '0106079783',
+    codDocModificado: '01',
+    numDocModificado: '001-001-000000123',
+    fechaEmisionDocSustento: '10/05/2025',
+    totalSinImpuestos: '100.00',
+    valorModificacion: '115.00',
+    motivo: 'DEVOLUCIÓN',
+  },
+  detalles: [
+    {
+      detalle: {
+        codigoInterno: 'P001',
+        descripcion: 'Laptop Lenovo',
+        cantidad: '1.00',
+        precioUnitario: '100.00',
+        precioTotalSinImpuesto: '100.00',
+        impuestos: [
+          {
+            impuesto: {
+              codigo: '2',
+              codigoPorcentaje: '4',
+              tarifa: '15.00',
+              baseImponible: '100.00',
+              valor: '15.00',
+            },
+          },
+        ],
+      },
+    },
+  ],
+};
+
+describe('obtenerConfiguracionIVA', () => {
+  const originalIva = process.env.IVA;
+  const originalCodigo = process.env.CODIGO_PORCENTAJE;
+
+  afterEach(() => {
+    process.env.IVA = originalIva;
+    process.env.CODIGO_PORCENTAJE = originalCodigo;
+    if (originalIva === undefined) delete process.env.IVA;
+    if (originalCodigo === undefined) delete process.env.CODIGO_PORCENTAJE;
+  });
+
+  it('defaults to 15% (codigoPorcentaje 4)', () => {
+    delete process.env.IVA;
+    delete process.env.CODIGO_PORCENTAJE;
+    expect(obtenerConfiguracionIVA()).toEqual({ tarifa: '15', codigoPorcentaje: '4' });
+  });
+
+  it('honors environment overrides', () => {
+    process.env.IVA = '12';
+    process.env.CODIGO_PORCENTAJE = '2';
+    expect(obtenerConfiguracionIVA()).toEqual({ tarifa: '12', codigoPorcentaje: '2' });
+  });
+});
+
+describe('generarClaveAcceso for credit notes', () => {
+  it('generates a 49-digit access key with document type 04', () => {
+    const clave = generarClaveAcceso({
+      fecha: new Date(Date.UTC(2025, 4, 17)),
+      tipoComprobante: '04',
+      ruc: '1790012345001',
+      ambiente: '1',
+      serie: '001001',
+      secuencial: '000000001',
+      codigoNumerico: '12345678',
+      tipoEmision: '1',
+    });
+
+    expect(clave).toHaveLength(49);
+    // ddmmyyyy (8) + tipoComprobante (2)
+    expect(clave.substring(0, 8)).toBe('17052025');
+    expect(clave.substring(8, 10)).toBe('04');
+    // Valid módulo 11 check digit
+    expect(clave[48]).toBe(obtenerDigitoVerificador(clave.substring(0, 48)));
+  });
+});
+
+describe('generarXMLNotaCredito', () => {
+  const xml = generarXMLNotaCredito(
+    notaCreditoMock,
+    empresaMock,
+    clienteMock,
+    '1705202504179001234500110010010000000011234567810',
+    '000000001',
+  );
+
+  it('generates the notaCredito root with version 1.1.0 and id comprobante', () => {
+    expect(xml).toContain('<notaCredito id="comprobante" version="1.1.0">');
+  });
+
+  it('uses codDoc 04', () => {
+    expect(xml).toContain('<codDoc>04</codDoc>');
+  });
+
+  it('includes the infoNotaCredito specific fields', () => {
+    expect(xml).toContain('<codDocModificado>01</codDocModificado>');
+    expect(xml).toContain('<numDocModificado>001-001-000000123</numDocModificado>');
+    expect(xml).toContain('<fechaEmisionDocSustento>10/05/2025</fechaEmisionDocSustento>');
+    expect(xml).toContain('<valorModificacion>115.00</valorModificacion>');
+    expect(xml).toContain('<motivo>DEVOLUCIÓN</motivo>');
+  });
+
+  it('uses codigoInterno for details (not codigoPrincipal)', () => {
+    expect(xml).toContain('<codigoInterno>P001</codigoInterno>');
+    expect(xml).not.toContain('codigoPrincipal');
+  });
+
+  it('takes tax codes from the request details', () => {
+    expect(xml).toContain('<codigoPorcentaje>4</codigoPorcentaje>');
+    expect(xml).toContain('<tarifa>15.00</tarifa>');
+  });
+
+  it('computes totalConImpuestos from the details', () => {
+    expect(xml).toContain('<baseImponible>100.00</baseImponible>');
+    expect(xml).toContain('<valor>15.00</valor>');
+  });
+});

--- a/__tests__/utils/debitNote.utils.test.ts
+++ b/__tests__/utils/debitNote.utils.test.ts
@@ -1,0 +1,142 @@
+import { generarXMLNotaDebito } from '../../src/utils/xml.utils';
+import { generarClaveAcceso, obtenerDigitoVerificador } from '../../src/utils/invoice.utils';
+import { DebitNoteRequest } from '../../src/interfaces/debit-note.interface';
+
+const empresaMock: any = {
+  tipo_ambiente: 1,
+  tipo_emision: 1,
+  razon_social: 'EMPRESA DEMO S.A.',
+  nombre_comercial: 'DEMO',
+  ruc: '1790012345001',
+  codigo_establecimiento: '001',
+  punto_emision: '001',
+  direccion_matriz: 'Av. Principal 123',
+  direccion_establecimiento: 'Av. Principal 123',
+  obligado_contabilidad: true,
+};
+
+const clienteMock: any = {
+  razon_social: 'CLIENTE DE PRUEBA',
+  identificacion: '0106079783',
+  email: 'cliente@test.com',
+  telefono: '0999999999',
+};
+
+const notaDebitoMock: DebitNoteRequest = {
+  infoTributaria: { ruc: '1790012345001', claveAcceso: '', secuencial: '' },
+  infoNotaDebito: {
+    fechaEmision: '17/05/2025',
+    tipoIdentificacionComprador: '05',
+    identificacionComprador: '0106079783',
+    codDocModificado: '01',
+    numDocModificado: '001-001-000000123',
+    fechaEmisionDocSustento: '10/05/2025',
+    totalSinImpuestos: '50.00',
+    impuestos: [
+      {
+        impuesto: {
+          codigo: '2',
+          codigoPorcentaje: '4',
+          tarifa: '15.00',
+          baseImponible: '50.00',
+          valor: '7.50',
+        },
+      },
+    ],
+    valorTotal: '57.50',
+    pagos: [
+      {
+        pago: {
+          formaPago: '20',
+          total: '57.50',
+          plazo: '15',
+          unidadTiempo: 'dias',
+        },
+      },
+    ],
+  },
+  motivos: [
+    {
+      motivo: {
+        razon: 'Interés por mora',
+        valor: '50.00',
+      },
+    },
+  ],
+};
+
+describe('generarClaveAcceso for debit notes', () => {
+  it('generates a 49-digit access key with document type 05', () => {
+    const clave = generarClaveAcceso({
+      fecha: new Date(Date.UTC(2025, 4, 17)),
+      tipoComprobante: '05',
+      ruc: '1790012345001',
+      ambiente: '1',
+      serie: '001001',
+      secuencial: '000000001',
+      codigoNumerico: '12345678',
+      tipoEmision: '1',
+    });
+
+    expect(clave).toHaveLength(49);
+    expect(clave.substring(8, 10)).toBe('05');
+    expect(clave[48]).toBe(obtenerDigitoVerificador(clave.substring(0, 48)));
+  });
+});
+
+describe('generarXMLNotaDebito', () => {
+  const xml = generarXMLNotaDebito(
+    notaDebitoMock,
+    empresaMock,
+    clienteMock,
+    '1705202505179001234500110010010000000011234567810',
+    '000000001',
+  );
+
+  it('generates the notaDebito root with version 1.0.0 and id comprobante', () => {
+    expect(xml).toContain('<notaDebito id="comprobante" version="1.0.0">');
+  });
+
+  it('uses codDoc 05', () => {
+    expect(xml).toContain('<codDoc>05</codDoc>');
+  });
+
+  it('includes the infoNotaDebito specific fields', () => {
+    expect(xml).toContain('<codDocModificado>01</codDocModificado>');
+    expect(xml).toContain('<numDocModificado>001-001-000000123</numDocModificado>');
+    expect(xml).toContain('<fechaEmisionDocSustento>10/05/2025</fechaEmisionDocSustento>');
+    expect(xml).toContain('<totalSinImpuestos>50.00</totalSinImpuestos>');
+    expect(xml).toContain('<valorTotal>57.50</valorTotal>');
+  });
+
+  it('includes the impuestos block with tax codes from the request', () => {
+    expect(xml).toContain('<codigoPorcentaje>4</codigoPorcentaje>');
+    expect(xml).toContain('<tarifa>15.00</tarifa>');
+    expect(xml).toContain('<valor>7.50</valor>');
+  });
+
+  it('includes the pagos block with optional plazo and unidadTiempo', () => {
+    expect(xml).toContain('<formaPago>20</formaPago>');
+    expect(xml).toContain('<total>57.50</total>');
+    expect(xml).toContain('<plazo>15</plazo>');
+    expect(xml).toContain('<unidadTiempo>dias</unidadTiempo>');
+  });
+
+  it('omits plazo and unidadTiempo when not provided', () => {
+    const sinPlazo: DebitNoteRequest = JSON.parse(JSON.stringify(notaDebitoMock));
+    delete sinPlazo.infoNotaDebito.pagos[0].pago.plazo;
+    delete sinPlazo.infoNotaDebito.pagos[0].pago.unidadTiempo;
+
+    const xmlSinPlazo = generarXMLNotaDebito(sinPlazo, empresaMock, clienteMock, 'clave', '000000001');
+
+    expect(xmlSinPlazo).not.toContain('<plazo>');
+    expect(xmlSinPlazo).not.toContain('<unidadTiempo>');
+  });
+
+  it('renders motivos with razon and valor instead of product detalles', () => {
+    expect(xml).toContain('<motivos>');
+    expect(xml).toContain('<razon>Interés por mora</razon>');
+    expect(xml).toContain('<valor>50.00</valor>');
+    expect(xml).not.toContain('<detalles>');
+  });
+});

--- a/__tests__/utils/deliveryNote.utils.test.ts
+++ b/__tests__/utils/deliveryNote.utils.test.ts
@@ -1,0 +1,159 @@
+import { generarXMLGuiaRemision } from '../../src/utils/xml.utils';
+import { generarClaveAcceso, obtenerDigitoVerificador } from '../../src/utils/invoice.utils';
+import { DeliveryNoteRequest } from '../../src/interfaces/delivery-note.interface';
+
+const empresaMock: any = {
+  tipo_ambiente: 1,
+  tipo_emision: 1,
+  razon_social: 'EMPRESA DEMO S.A.',
+  nombre_comercial: 'DEMO',
+  ruc: '1790012345001',
+  codigo_establecimiento: '001',
+  punto_emision: '001',
+  direccion_matriz: 'Av. Principal 123',
+  direccion_establecimiento: 'Av. Principal 123',
+  obligado_contabilidad: true,
+};
+
+const guiaRemisionMock: DeliveryNoteRequest = {
+  infoTributaria: { ruc: '1790012345001', claveAcceso: '', secuencial: '' },
+  infoGuiaRemision: {
+    fechaEmision: '17/05/2025',
+    dirPartida: 'Av. Eloy Alfaro 34 y Av. Libertad',
+    razonSocialTransportista: 'Transportes S.A.',
+    tipoIdentificacionTransportista: '04',
+    rucTransportista: '1796875790001',
+    fechaIniTransporte: '17/05/2025',
+    fechaFinTransporte: '18/05/2025',
+    placa: 'MCL0827',
+  },
+  destinatarios: [
+    {
+      destinatario: {
+        identificacionDestinatario: '1716849140001',
+        razonSocialDestinatario: 'Juan Pérez',
+        dirDestinatario: 'Av. Simón Bolívar S/N',
+        motivoTraslado: 'Venta de mercadería',
+        ruta: 'Quito - Cayambe - Otavalo',
+        codDocSustento: '01',
+        numDocSustento: '001-001-000000123',
+        numAutDocSustento: '1705202501179001234500110010010000000011234567810',
+        fechaEmisionDocSustento: '17/05/2025',
+        detalles: [
+          {
+            detalle: {
+              codigoInterno: 'P001',
+              descripcion: 'Laptop Lenovo',
+              cantidad: '10.00',
+            },
+          },
+          {
+            detalle: {
+              descripcion: 'Mouse inalámbrico',
+              cantidad: '25.00',
+            },
+          },
+        ],
+      },
+    },
+    {
+      destinatario: {
+        identificacionDestinatario: '0106079783',
+        razonSocialDestinatario: 'María García',
+        dirDestinatario: 'Calle Larga 456',
+        motivoTraslado: 'Traslado entre bodegas',
+        detalles: [
+          {
+            detalle: {
+              descripcion: 'Monitor 24 pulgadas',
+              cantidad: '5.00',
+            },
+          },
+        ],
+      },
+    },
+  ],
+};
+
+describe('generarClaveAcceso for delivery notes', () => {
+  it('generates a 49-digit access key with document type 06', () => {
+    const clave = generarClaveAcceso({
+      fecha: new Date(Date.UTC(2025, 4, 17)),
+      tipoComprobante: '06',
+      ruc: '1790012345001',
+      ambiente: '1',
+      serie: '001001',
+      secuencial: '000000001',
+      codigoNumerico: '12345678',
+      tipoEmision: '1',
+    });
+
+    expect(clave).toHaveLength(49);
+    expect(clave.substring(8, 10)).toBe('06');
+    expect(clave[48]).toBe(obtenerDigitoVerificador(clave.substring(0, 48)));
+  });
+});
+
+describe('generarXMLGuiaRemision', () => {
+  const xml = generarXMLGuiaRemision(
+    guiaRemisionMock,
+    empresaMock,
+    '1705202506179001234500110010010000000011234567810',
+    '000000001',
+  );
+
+  it('generates the guiaRemision root with version 1.1.0 and id comprobante', () => {
+    expect(xml).toContain('<guiaRemision id="comprobante" version="1.1.0">');
+  });
+
+  it('uses codDoc 06', () => {
+    expect(xml).toContain('<codDoc>06</codDoc>');
+  });
+
+  it('includes the transport information', () => {
+    expect(xml).toContain('<dirPartida>Av. Eloy Alfaro 34 y Av. Libertad</dirPartida>');
+    expect(xml).toContain('<razonSocialTransportista>Transportes S.A.</razonSocialTransportista>');
+    expect(xml).toContain('<tipoIdentificacionTransportista>04</tipoIdentificacionTransportista>');
+    expect(xml).toContain('<rucTransportista>1796875790001</rucTransportista>');
+    expect(xml).toContain('<fechaIniTransporte>17/05/2025</fechaIniTransporte>');
+    expect(xml).toContain('<fechaFinTransporte>18/05/2025</fechaFinTransporte>');
+    expect(xml).toContain('<placa>MCL0827</placa>');
+  });
+
+  it('renders every destinatario with its own detalles', () => {
+    expect((xml.match(/<destinatario>/g) || []).length).toBe(2);
+    expect(xml).toContain('<identificacionDestinatario>1716849140001</identificacionDestinatario>');
+    expect(xml).toContain('<identificacionDestinatario>0106079783</identificacionDestinatario>');
+    expect((xml.match(/<detalles>/g) || []).length).toBe(2);
+    expect((xml.match(/<detalle>/g) || []).length).toBe(3);
+  });
+
+  it('includes the documento de sustento fields when provided', () => {
+    expect(xml).toContain('<codDocSustento>01</codDocSustento>');
+    expect(xml).toContain('<numDocSustento>001-001-000000123</numDocSustento>');
+    expect(xml).toContain('<ruta>Quito - Cayambe - Otavalo</ruta>');
+  });
+
+  it('omits optional fields when not provided', () => {
+    // Second destinatario has no ruta/doc sustento; second detalle has no codigoInterno
+    expect((xml.match(/<ruta>/g) || []).length).toBe(1);
+    expect((xml.match(/<codDocSustento>/g) || []).length).toBe(1);
+    expect((xml.match(/<codigoInterno>/g) || []).length).toBe(1);
+  });
+
+  it('contains no monetary fields', () => {
+    expect(xml).not.toContain('precioUnitario');
+    expect(xml).not.toContain('totalSinImpuestos');
+    expect(xml).not.toContain('importeTotal');
+    expect(xml).not.toContain('<impuestos>');
+  });
+
+  it('nests detalles inside each destinatario', () => {
+    const primerDestinatario = xml.substring(
+      xml.indexOf('<destinatario>'),
+      xml.indexOf('</destinatario>') + '</destinatario>'.length,
+    );
+    expect(primerDestinatario).toContain('<descripcion>Laptop Lenovo</descripcion>');
+    expect(primerDestinatario).toContain('<cantidad>10.00</cantidad>');
+  });
+});

--- a/__tests__/utils/email.utils.test.ts
+++ b/__tests__/utils/email.utils.test.ts
@@ -1,0 +1,129 @@
+const sendMailMock = jest.fn().mockResolvedValue({ messageId: 'msg-123' });
+
+jest.mock('nodemailer', () => ({
+  __esModule: true,
+  default: {
+    createTransport: jest.fn(() => ({ sendMail: sendMailMock })),
+  },
+}));
+
+import nodemailer from 'nodemailer';
+import {
+  generateInvoiceEmailTemplate,
+  prepareEmailConfig,
+  isValidEmail,
+  sendInvoiceEmail,
+} from '../../src/utils/email.utils';
+
+const invoicePDFMock: any = {
+  claveAcceso: '1705202501179001234500110010010000000011234567810',
+  numero_autorizacion: '1705202501179001234500110010010000000011234567810',
+  fecha_autorizacion: new Date('2025-05-17T12:00:00Z'),
+  fecha_generacion: new Date('2025-05-17T12:05:00Z'),
+  pdf_url: 'https://cdn.example.com/factura.pdf',
+};
+
+describe('isValidEmail', () => {
+  it('accepts valid emails', () => {
+    expect(isValidEmail('cliente@test.com')).toBe(true);
+    expect(isValidEmail('a.b+c@sub.dominio.ec')).toBe(true);
+  });
+
+  it('rejects invalid emails', () => {
+    expect(isValidEmail('no-arroba')).toBe(false);
+    expect(isValidEmail('a@b')).toBe(false);
+    expect(isValidEmail('a b@c.com')).toBe(false);
+    expect(isValidEmail('')).toBe(false);
+  });
+});
+
+describe('generateInvoiceEmailTemplate', () => {
+  it('builds subject, html and text with the invoice data', () => {
+    const template = generateInvoiceEmailTemplate(invoicePDFMock, 'Juan Pérez', 'EMPRESA DEMO S.A.');
+
+    expect(template.subject).toContain(invoicePDFMock.claveAcceso);
+    expect(template.html).toContain('Juan Pérez');
+    expect(template.html).toContain('EMPRESA DEMO S.A.');
+    expect(template.html).toContain(invoicePDFMock.pdf_url);
+    expect(template.text).toContain(invoicePDFMock.claveAcceso);
+    expect(template.text).toContain(invoicePDFMock.pdf_url);
+  });
+
+  it('throws when the PDF URL is missing', () => {
+    expect(() => generateInvoiceEmailTemplate({ ...invoicePDFMock, pdf_url: '' }, 'Juan', 'Empresa')).toThrow(
+      'PDF URL no disponible',
+    );
+  });
+});
+
+describe('prepareEmailConfig', () => {
+  it('maps the template into a sendable config without attachments', () => {
+    const template = { subject: 's', html: '<p>h</p>', text: 't' };
+    const config = prepareEmailConfig(invoicePDFMock, template, 'cliente@test.com');
+
+    expect(config).toEqual({
+      to: 'cliente@test.com',
+      subject: 's',
+      html: '<p>h</p>',
+      text: 't',
+    });
+  });
+});
+
+describe('sendInvoiceEmail', () => {
+  const originalUser = process.env.EMAIL_USER;
+  const originalPassword = process.env.EMAIL_PASSWORD;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.EMAIL_USER = 'emisor@test.com';
+    process.env.EMAIL_PASSWORD = 'test-email-password';
+  });
+
+  afterAll(() => {
+    process.env.EMAIL_USER = originalUser;
+    process.env.EMAIL_PASSWORD = originalPassword;
+    if (originalUser === undefined) delete process.env.EMAIL_USER;
+    if (originalPassword === undefined) delete process.env.EMAIL_PASSWORD;
+  });
+
+  it('sends the email and returns the messageId', async () => {
+    const result = await sendInvoiceEmail(invoicePDFMock, 'cliente@test.com', 'Juan', 'Empresa');
+
+    expect(result).toEqual({ success: true, messageId: 'msg-123' });
+    expect(nodemailer.createTransport).toHaveBeenCalledWith(
+      expect.objectContaining({ auth: { user: 'emisor@test.com', pass: 'test-email-password' } }),
+    );
+    expect(sendMailMock).toHaveBeenCalledWith(
+      expect.objectContaining({ from: 'emisor@test.com', to: 'cliente@test.com' }),
+    );
+  });
+
+  it('fails for an invalid recipient email', async () => {
+    const result = await sendInvoiceEmail(invoicePDFMock, 'invalido', 'Juan', 'Empresa');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('email inválido');
+    expect(sendMailMock).not.toHaveBeenCalled();
+  });
+
+  it('fails gracefully when email credentials are not configured', async () => {
+    delete process.env.EMAIL_USER;
+    delete process.env.EMAIL_PASSWORD;
+
+    const result = await sendInvoiceEmail(invoicePDFMock, 'cliente@test.com', 'Juan', 'Empresa');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('no configurado');
+    expect(sendMailMock).not.toHaveBeenCalled();
+  });
+
+  it('returns the error when the transport fails', async () => {
+    sendMailMock.mockRejectedValueOnce(new Error('SMTP down'));
+
+    const result = await sendInvoiceEmail(invoicePDFMock, 'cliente@test.com', 'Juan', 'Empresa');
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('SMTP down');
+  });
+});

--- a/__tests__/utils/firma.utils.test.ts
+++ b/__tests__/utils/firma.utils.test.ts
@@ -5,13 +5,18 @@ import forge from 'node-forge';
 
 const signInvoiceXmlMock = jest.fn().mockReturnValue('<factura>firmada</factura>');
 const signCreditNoteXmlMock = jest.fn().mockReturnValue('<notaCredito>firmada</notaCredito>');
+const signDebitNoteXmlMock = jest.fn().mockReturnValue('<notaDebito>firmada</notaDebito>');
+const signDeliveryGuideXmlMock = jest.fn().mockReturnValue('<guiaRemision>firmada</guiaRemision>');
+const signWithholdingCertificateXmlMock = jest
+  .fn()
+  .mockReturnValue('<comprobanteRetencion>firmada</comprobanteRetencion>');
 
 jest.mock('ec-sri-invoice-signer', () => ({
   signInvoiceXml: (...args: any[]) => signInvoiceXmlMock(...args),
   signCreditNoteXml: (...args: any[]) => signCreditNoteXmlMock(...args),
-  signDebitNoteXml: jest.fn(),
-  signDeliveryGuideXml: jest.fn(),
-  signWithholdingCertificateXml: jest.fn(),
+  signDebitNoteXml: (...args: any[]) => signDebitNoteXmlMock(...args),
+  signDeliveryGuideXml: (...args: any[]) => signDeliveryGuideXmlMock(...args),
+  signWithholdingCertificateXml: (...args: any[]) => signWithholdingCertificateXmlMock(...args),
 }));
 
 import { firmarXML } from '../../src/utils/firma.utils';
@@ -42,6 +47,51 @@ function crearP12DePrueba(): string {
   const p12Der = forge.asn1.toDer(p12Asn1).getBytes();
 
   const p12Path = path.join(os.tmpdir(), `test-cert-${Date.now()}.p12`);
+  fs.writeFileSync(p12Path, Buffer.from(p12Der, 'binary'));
+  return p12Path;
+}
+
+/**
+ * Builds a P12 file bundling the signer certificate and its CA chain,
+ * as issued by Ecuadorian certificate authorities (BCE, Security Data)
+ */
+function crearP12ConCadenaCA(): string {
+  const caKeys = forge.pki.rsa.generateKeyPair(2048);
+  const caCert = forge.pki.createCertificate();
+  caCert.publicKey = caKeys.publicKey;
+  caCert.serialNumber = '99';
+  caCert.validity.notBefore = new Date();
+  caCert.validity.notAfter = new Date();
+  caCert.validity.notAfter.setFullYear(caCert.validity.notBefore.getFullYear() + 5);
+  const caAttrs = [
+    { shortName: 'CN', value: 'AUTORIDAD DE CERTIFICACION PRUEBAS' },
+    { shortName: 'C', value: 'EC' },
+  ];
+  caCert.setSubject(caAttrs);
+  caCert.setIssuer(caAttrs);
+  caCert.setExtensions([{ name: 'basicConstraints', cA: true }]);
+  caCert.sign(caKeys.privateKey, forge.md.sha256.create());
+
+  const keys = forge.pki.rsa.generateKeyPair(2048);
+  const cert = forge.pki.createCertificate();
+  cert.publicKey = keys.publicKey;
+  cert.serialNumber = '02';
+  cert.validity.notBefore = new Date();
+  cert.validity.notAfter = new Date();
+  cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 1);
+  cert.setSubject([
+    { shortName: 'CN', value: 'MARIA GARCIA' },
+    { shortName: 'C', value: 'EC' },
+  ]);
+  cert.setIssuer(caAttrs);
+  cert.setExtensions([{ name: 'basicConstraints', cA: false }]);
+  cert.sign(caKeys.privateKey, forge.md.sha256.create());
+
+  // CA first so the signer certificate is NOT the first certBag in the file
+  const p12Asn1 = forge.pkcs12.toPkcs12Asn1(keys.privateKey, [caCert, cert] as any, P12_PASSWORD);
+  const p12Der = forge.asn1.toDer(p12Asn1).getBytes();
+
+  const p12Path = path.join(os.tmpdir(), `test-cert-ca-${Date.now()}.p12`);
   fs.writeFileSync(p12Path, Buffer.from(p12Der, 'binary'));
   return p12Path;
 }
@@ -85,6 +135,37 @@ describe('firmarXML', () => {
     expect(Buffer.isBuffer(p12Buffer)).toBe(true);
     expect(p12Buffer.length).toBeGreaterThan(0);
     expect(options).toEqual({ pkcs12Password: P12_PASSWORD });
+  });
+
+  it('signs debit notes, delivery guides and withholding certificates by tipoDocumento', async () => {
+    await firmarXML('<notaDebito id="comprobante"/>', p12Path, P12_PASSWORD, '05');
+    await firmarXML('<guiaRemision id="comprobante"/>', p12Path, P12_PASSWORD, '06');
+    await firmarXML('<comprobanteRetencion id="comprobante"/>', p12Path, P12_PASSWORD, '07');
+
+    expect(signDebitNoteXmlMock).toHaveBeenCalledTimes(1);
+    expect(signDeliveryGuideXmlMock).toHaveBeenCalledTimes(1);
+    expect(signWithholdingCertificateXmlMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('selects the non-CA signing certificate from a P12 with a CA chain', async () => {
+    const p12ConCadena = crearP12ConCadenaCA();
+
+    try {
+      const resultado = await firmarXML('<factura id="comprobante"/>', p12ConCadena, P12_PASSWORD);
+
+      expect(resultado).toBe('<factura>firmada</factura>');
+      // The signer received a rebuilt minimal P12 containing exactly one certificate
+      const [, p12Minimo] = signInvoiceXmlMock.mock.calls[0];
+      const forgeLib = jest.requireActual('node-forge');
+      const asn1 = forgeLib.asn1.fromDer(forgeLib.util.decode64(p12Minimo.toString('base64')));
+      const p12 = forgeLib.pkcs12.pkcs12FromAsn1(asn1, true, P12_PASSWORD);
+      const certBags = p12.getBags({ bagType: forgeLib.pki.oids.certBag })[forgeLib.pki.oids.certBag] || [];
+      expect(certBags).toHaveLength(1);
+      const cn = certBags[0].cert.subject.getField({ shortName: 'CN' }).value;
+      expect(cn).toBe('MARIA GARCIA');
+    } finally {
+      fs.unlinkSync(p12ConCadena);
+    }
   });
 
   it('throws a descriptive error when the P12 password is wrong', async () => {

--- a/__tests__/utils/firma.utils.test.ts
+++ b/__tests__/utils/firma.utils.test.ts
@@ -1,0 +1,101 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import forge from 'node-forge';
+
+const signInvoiceXmlMock = jest.fn().mockReturnValue('<factura>firmada</factura>');
+const signCreditNoteXmlMock = jest.fn().mockReturnValue('<notaCredito>firmada</notaCredito>');
+
+jest.mock('ec-sri-invoice-signer', () => ({
+  signInvoiceXml: (...args: any[]) => signInvoiceXmlMock(...args),
+  signCreditNoteXml: (...args: any[]) => signCreditNoteXmlMock(...args),
+  signDebitNoteXml: jest.fn(),
+  signDeliveryGuideXml: jest.fn(),
+  signWithholdingCertificateXml: jest.fn(),
+}));
+
+import { firmarXML } from '../../src/utils/firma.utils';
+
+const P12_PASSWORD = 'test-password';
+
+/**
+ * Builds a self-signed certificate P12 file for testing
+ */
+function crearP12DePrueba(): string {
+  const keys = forge.pki.rsa.generateKeyPair(2048);
+  const cert = forge.pki.createCertificate();
+  cert.publicKey = keys.publicKey;
+  cert.serialNumber = '01';
+  cert.validity.notBefore = new Date();
+  cert.validity.notAfter = new Date();
+  cert.validity.notAfter.setFullYear(cert.validity.notBefore.getFullYear() + 1);
+
+  const attrs = [
+    { shortName: 'CN', value: 'JUAN PEREZ' },
+    { shortName: 'C', value: 'EC' },
+  ];
+  cert.setSubject(attrs);
+  cert.setIssuer(attrs);
+  cert.sign(keys.privateKey, forge.md.sha256.create());
+
+  const p12Asn1 = forge.pkcs12.toPkcs12Asn1(keys.privateKey, cert, P12_PASSWORD);
+  const p12Der = forge.asn1.toDer(p12Asn1).getBytes();
+
+  const p12Path = path.join(os.tmpdir(), `test-cert-${Date.now()}.p12`);
+  fs.writeFileSync(p12Path, Buffer.from(p12Der, 'binary'));
+  return p12Path;
+}
+
+describe('firmarXML', () => {
+  let p12Path: string;
+
+  beforeAll(() => {
+    p12Path = crearP12DePrueba();
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(p12Path)) fs.unlinkSync(p12Path);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('signs invoices with signInvoiceXml by default', async () => {
+    const resultado = await firmarXML('<factura id="comprobante"/>', p12Path, P12_PASSWORD);
+
+    expect(signInvoiceXmlMock).toHaveBeenCalledTimes(1);
+    expect(signCreditNoteXmlMock).not.toHaveBeenCalled();
+    expect(resultado).toBe('<factura>firmada</factura>');
+  });
+
+  it('signs credit notes with signCreditNoteXml when tipoDocumento is 04', async () => {
+    const resultado = await firmarXML('<notaCredito id="comprobante"/>', p12Path, P12_PASSWORD, '04');
+
+    expect(signCreditNoteXmlMock).toHaveBeenCalledTimes(1);
+    expect(signInvoiceXmlMock).not.toHaveBeenCalled();
+    expect(resultado).toBe('<notaCredito>firmada</notaCredito>');
+  });
+
+  it('passes a rebuilt minimal P12 buffer and the password to the signer', async () => {
+    await firmarXML('<notaCredito id="comprobante"/>', p12Path, P12_PASSWORD, '04');
+
+    const [xml, p12Buffer, options] = signCreditNoteXmlMock.mock.calls[0];
+    expect(xml).toBe('<notaCredito id="comprobante"/>');
+    expect(Buffer.isBuffer(p12Buffer)).toBe(true);
+    expect(p12Buffer.length).toBeGreaterThan(0);
+    expect(options).toEqual({ pkcs12Password: P12_PASSWORD });
+  });
+
+  it('throws a descriptive error when the P12 password is wrong', async () => {
+    await expect(firmarXML('<factura id="comprobante"/>', p12Path, 'wrong-password')).rejects.toThrow(
+      'Error al firmar XML',
+    );
+  });
+
+  it('throws a descriptive error when the P12 file does not exist', async () => {
+    await expect(firmarXML('<factura id="comprobante"/>', '/tmp/no-existe.p12', P12_PASSWORD)).rejects.toThrow(
+      'Error al firmar XML',
+    );
+  });
+});

--- a/__tests__/utils/invoice.utils.test.ts
+++ b/__tests__/utils/invoice.utils.test.ts
@@ -1,0 +1,64 @@
+import { convertirFecha, generarClaveAcceso, obtenerDigitoVerificador } from '../../src/utils/invoice.utils';
+
+describe('convertirFecha', () => {
+  it('parses DD/MM/YYYY dates', () => {
+    const fecha = convertirFecha('17/05/2025');
+
+    expect(fecha.getFullYear()).toBe(2025);
+    expect(fecha.getMonth()).toBe(4);
+  });
+
+  it('parses ISO dates without slashes', () => {
+    const fecha = convertirFecha('2025-05-17');
+
+    expect(isNaN(fecha.getTime())).toBe(false);
+    expect(fecha.getUTCFullYear()).toBe(2025);
+  });
+
+  it('falls back to the native parser for slash dates with unexpected parts', () => {
+    const fecha = convertirFecha('05/2025');
+
+    expect(fecha).toBeInstanceOf(Date);
+  });
+
+  it('returns an invalid date for garbage input', () => {
+    expect(isNaN(convertirFecha('no-es-fecha').getTime())).toBe(true);
+  });
+});
+
+describe('obtenerDigitoVerificador', () => {
+  it('applies módulo 11 with the 2-7 coefficient cycle', () => {
+    expect(obtenerDigitoVerificador('41261533')).toBe('6');
+  });
+
+  it('maps a módulo result of 11 to 0', () => {
+    // '451': 1*2 + 5*3 + 4*4 = 33 → 33 % 11 = 0 → dígito 0
+    expect(obtenerDigitoVerificador('451')).toBe('0');
+  });
+
+  it('maps a módulo result of 10 to 1', () => {
+    // '23': 3*2 + 2*3 = 12 → 12 % 11 = 1 → 11 - 1 = 10 → dígito 1
+    expect(obtenerDigitoVerificador('23')).toBe('1');
+  });
+});
+
+describe('generarClaveAcceso', () => {
+  it('assembles the 49-digit key from its components in order', () => {
+    const clave = generarClaveAcceso({
+      fecha: new Date(Date.UTC(2025, 0, 5)),
+      tipoComprobante: '01',
+      ruc: '1790012345001',
+      ambiente: '2',
+      serie: '001002',
+      secuencial: '000000042',
+      codigoNumerico: '87654321',
+      tipoEmision: '1',
+    });
+
+    expect(clave).toHaveLength(49);
+    expect(
+      clave.startsWith('05012025' + '01' + '1790012345001' + '2' + '001002' + '000000042' + '87654321' + '1'),
+    ).toBe(true);
+    expect(clave[48]).toBe(obtenerDigitoVerificador(clave.substring(0, 48)));
+  });
+});

--- a/__tests__/utils/pdf.utils.test.ts
+++ b/__tests__/utils/pdf.utils.test.ts
@@ -1,0 +1,299 @@
+const setContentMock = jest.fn();
+const pdfMock = jest.fn().mockResolvedValue(Buffer.from('pdf-bytes'));
+const closeMock = jest.fn();
+const launchMock = jest.fn().mockResolvedValue({
+  newPage: jest.fn().mockResolvedValue({
+    setViewport: jest.fn(),
+    setContent: setContentMock,
+    pdf: pdfMock,
+  }),
+  close: closeMock,
+});
+
+jest.mock('puppeteer', () => ({
+  __esModule: true,
+  default: { launch: (...args: any[]) => launchMock(...args) },
+}));
+
+import fs from 'fs';
+import {
+  generateInvoicePDF,
+  generateCreditNotePDF,
+  generateDebitNotePDF,
+  generateDeliveryNotePDF,
+  generateWithholdingPDF,
+  savePDFToFile,
+} from '../../src/utils/pdf.utils';
+
+const empresaMock: any = {
+  tipo_ambiente: 1,
+  tipo_emision: 1,
+  razon_social: 'EMPRESA DEMO S.A.',
+  nombre_comercial: 'DEMO',
+  ruc: '1790012345001',
+  codigo_establecimiento: '001',
+  punto_emision: '001',
+  direccion_matriz: 'Av. Principal 123',
+  direccion_establecimiento: 'Av. Principal 123',
+  obligado_contabilidad: true,
+};
+
+const clienteMock: any = {
+  razon_social: 'CLIENTE DE PRUEBA',
+  identificacion: '0106079783',
+  direccion: 'Calle Larga 456',
+  email: 'cliente@test.com',
+  telefono: '0999999999',
+};
+
+const productoMock: any = { descripcion_adicional: 'Serie X' };
+
+const baseData = {
+  empresa: empresaMock,
+  cliente: clienteMock,
+  claveAcceso: '1705202501179001234500110010010000000011234567810',
+  secuencial: '000000001',
+  fechaEmision: new Date('2025-05-17T12:00:00Z'),
+  numeroAutorizacion: '1705202501179001234500110010010000000011234567810',
+  fechaAutorizacion: new Date('2025-05-17T12:05:00Z'),
+};
+
+const ultimoHTML = () => setContentMock.mock.calls[setContentMock.mock.calls.length - 1][0] as string;
+
+describe('PDF generators', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('generates the invoice RIDE with totals and client info', async () => {
+    const buffer = await generateInvoicePDF({
+      ...baseData,
+      factura: {
+        infoFactura: { totalSinImpuestos: '100.00', importeTotal: '115.00' },
+        detalles: [
+          {
+            detalle: {
+              descripcion: 'Laptop Lenovo',
+              cantidad: '1.00',
+              precioUnitario: '100.00',
+              precioTotalSinImpuesto: '100.00',
+            },
+          },
+        ],
+      },
+      productos: [productoMock],
+    } as any);
+
+    expect(Buffer.isBuffer(buffer)).toBe(true);
+    const html = ultimoHTML();
+    expect(html).toContain('FACTURA');
+    expect(html).toContain('EMPRESA DEMO S.A.');
+    expect(html).toContain('CLIENTE DE PRUEBA');
+    expect(html).toContain('Laptop Lenovo');
+    expect(html).toContain('$115.00');
+    expect(html).toContain(baseData.claveAcceso);
+  });
+
+  it('generates the credit note RIDE with the modified document info', async () => {
+    await generateCreditNotePDF({
+      ...baseData,
+      productos: [productoMock],
+      notaCredito: {
+        infoTributaria: { ruc: empresaMock.ruc },
+        infoNotaCredito: {
+          fechaEmision: '17/05/2025',
+          tipoIdentificacionComprador: '05',
+          identificacionComprador: clienteMock.identificacion,
+          codDocModificado: '01',
+          numDocModificado: '001-001-000000123',
+          fechaEmisionDocSustento: '10/05/2025',
+          totalSinImpuestos: '100.00',
+          valorModificacion: '115.00',
+          motivo: 'DEVOLUCIÓN',
+        },
+        detalles: [
+          {
+            detalle: {
+              codigoInterno: 'P001',
+              descripcion: 'Laptop Lenovo',
+              cantidad: '1.00',
+              precioUnitario: '100.00',
+              precioTotalSinImpuesto: '100.00',
+              impuestos: [
+                {
+                  impuesto: {
+                    codigo: '2',
+                    codigoPorcentaje: '4',
+                    tarifa: '15.00',
+                    baseImponible: '100.00',
+                    valor: '15.00',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    } as any);
+
+    const html = ultimoHTML();
+    expect(html).toContain('NOTA DE CRÉDITO');
+    expect(html).toContain('FACTURA 001-001-000000123');
+    expect(html).toContain('DEVOLUCIÓN');
+  });
+
+  it('generates the debit note RIDE with the motivos as line items', async () => {
+    await generateDebitNotePDF({
+      ...baseData,
+      notaDebito: {
+        infoTributaria: { ruc: empresaMock.ruc },
+        infoNotaDebito: {
+          fechaEmision: '17/05/2025',
+          tipoIdentificacionComprador: '05',
+          identificacionComprador: clienteMock.identificacion,
+          codDocModificado: '01',
+          numDocModificado: '001-001-000000123',
+          fechaEmisionDocSustento: '10/05/2025',
+          totalSinImpuestos: '50.00',
+          impuestos: [
+            {
+              impuesto: { codigo: '2', codigoPorcentaje: '4', tarifa: '15.00', baseImponible: '50.00', valor: '7.50' },
+            },
+          ],
+          valorTotal: '57.50',
+          pagos: [{ pago: { formaPago: '20', total: '57.50' } }],
+        },
+        motivos: [{ motivo: { razon: 'Interés por mora', valor: '50.00' } }],
+      },
+    } as any);
+
+    const html = ultimoHTML();
+    expect(html).toContain('NOTA DE DÉBITO');
+    expect(html).toContain('Interés por mora');
+    expect(html).toContain('$57.50');
+  });
+
+  it('generates the delivery note RIDE with transport and destinatarios (no totals)', async () => {
+    await generateDeliveryNotePDF({
+      ...baseData,
+      guiaRemision: {
+        infoTributaria: { ruc: empresaMock.ruc },
+        infoGuiaRemision: {
+          fechaEmision: '17/05/2025',
+          dirPartida: 'Av. Eloy Alfaro 34',
+          razonSocialTransportista: 'Transportes S.A.',
+          tipoIdentificacionTransportista: '04',
+          rucTransportista: '1796875790001',
+          fechaIniTransporte: '17/05/2025',
+          fechaFinTransporte: '18/05/2025',
+          placa: 'MCL0827',
+        },
+        destinatarios: [
+          {
+            destinatario: {
+              identificacionDestinatario: '1716849140001',
+              razonSocialDestinatario: 'Juan Pérez',
+              dirDestinatario: 'Av. Simón Bolívar S/N',
+              motivoTraslado: 'Venta de mercadería',
+              codDocSustento: '01',
+              numDocSustento: '001-001-000000123',
+              fechaEmisionDocSustento: '17/05/2025',
+              detalles: [{ detalle: { codigoInterno: 'P001', descripcion: 'Laptop Lenovo', cantidad: '10.00' } }],
+            },
+          },
+        ],
+      },
+    } as any);
+
+    const html = ultimoHTML();
+    expect(html).toContain('GUÍA DE REMISIÓN');
+    expect(html).toContain('Transportes S.A.');
+    expect(html).toContain('MCL0827');
+    expect(html).toContain('Juan Pérez');
+    expect(html).toContain('FACTURA 001-001-000000123');
+    expect(html).not.toContain('VALOR TOTAL');
+  });
+
+  it('generates the withholding RIDE with the retenciones table and total', async () => {
+    await generateWithholdingPDF({
+      ...baseData,
+      retencion: {
+        infoTributaria: { ruc: empresaMock.ruc },
+        infoCompRetencion: {
+          fechaEmision: '17/05/2025',
+          tipoIdentificacionSujetoRetenido: '04',
+          razonSocialSujetoRetenido: 'Proveedor S.A.',
+          identificacionSujetoRetenido: '1713328506001',
+          periodoFiscal: '05/2025',
+        },
+        docsSustento: [
+          {
+            docSustento: {
+              codSustento: '01',
+              codDocSustento: '01',
+              numDocSustento: '001001000000123',
+              fechaEmisionDocSustento: '10/05/2025',
+              pagoLocExt: '01',
+              totalSinImpuestos: '100.00',
+              importeTotal: '115.00',
+              impuestosDocSustento: [],
+              retenciones: [
+                {
+                  retencion: {
+                    codigo: '1',
+                    codigoRetencion: '312',
+                    baseImponible: '100.00',
+                    porcentajeRetener: '1.75',
+                    valorRetenido: '1.75',
+                  },
+                },
+                {
+                  retencion: {
+                    codigo: '2',
+                    codigoRetencion: '3',
+                    baseImponible: '15.00',
+                    porcentajeRetener: '70',
+                    valorRetenido: '10.50',
+                  },
+                },
+              ],
+              pagos: [{ pago: { formaPago: '01', total: '115.00' } }],
+            },
+          },
+        ],
+      },
+    } as any);
+
+    const html = ultimoHTML();
+    expect(html).toContain('COMPROBANTE DE RETENCIÓN');
+    expect(html).toContain('Proveedor S.A.');
+    expect(html).toContain('RENTA');
+    expect(html).toContain('IVA');
+    expect(html).toContain('312');
+    expect(html).toContain('$12.25'); // 1.75 + 10.50
+  });
+
+  it('closes the browser and rethrows when PDF rendering fails', async () => {
+    pdfMock.mockRejectedValueOnce(new Error('render failed'));
+
+    await expect(
+      generateInvoicePDF({
+        ...baseData,
+        factura: { infoFactura: { totalSinImpuestos: '1', importeTotal: '1' }, detalles: [] },
+        productos: [],
+      } as any),
+    ).rejects.toThrow('Failed to generate PDF');
+
+    expect(closeMock).toHaveBeenCalled();
+  });
+});
+
+describe('savePDFToFile', () => {
+  it('writes the buffer to a temp file and returns its path', async () => {
+    const filePath = await savePDFToFile(Buffer.from('pdf'), `test-pdf-${process.pid}`);
+
+    expect(filePath).toContain('test-pdf');
+    expect(fs.existsSync(filePath)).toBe(true);
+    fs.unlinkSync(filePath);
+  });
+});

--- a/__tests__/utils/sri.autorizacion.test.ts
+++ b/__tests__/utils/sri.autorizacion.test.ts
@@ -1,0 +1,119 @@
+import axios from 'axios';
+import { autorizarComprobanteSRI } from '../../src/utils/sri.utils';
+
+jest.mock('axios');
+const axiosMock = axios as jest.Mocked<typeof axios>;
+
+const CLAVE_ACCESO = '1705202504179001234500110010010000000011234567810';
+
+const respuestaAutorizado = `<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <ns2:autorizacionComprobanteResponse xmlns:ns2="http://ec.gob.sri.ws.autorizacion">
+      <RespuestaAutorizacionComprobante>
+        <claveAccesoConsultada>${CLAVE_ACCESO}</claveAccesoConsultada>
+        <numeroComprobantes>1</numeroComprobantes>
+        <autorizaciones>
+          <autorizacion>
+            <estado>AUTORIZADO</estado>
+            <numeroAutorizacion>${CLAVE_ACCESO}</numeroAutorizacion>
+            <fechaAutorizacion>2025-05-17T12:00:00-05:00</fechaAutorizacion>
+            <ambiente>PRUEBAS</ambiente>
+            <comprobante><![CDATA[<notaCredito/>]]></comprobante>
+          </autorizacion>
+        </autorizaciones>
+      </RespuestaAutorizacionComprobante>
+    </ns2:autorizacionComprobanteResponse>
+  </soap:Body>
+</soap:Envelope>`;
+
+const respuestaNoAutorizado = `<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <ns2:autorizacionComprobanteResponse xmlns:ns2="http://ec.gob.sri.ws.autorizacion">
+      <RespuestaAutorizacionComprobante>
+        <autorizaciones>
+          <autorizacion>
+            <estado>NO AUTORIZADO</estado>
+            <fechaAutorizacion>2025-05-17T12:00:00-05:00</fechaAutorizacion>
+            <ambiente>PRUEBAS</ambiente>
+            <mensajes>
+              <mensaje>
+                <identificador>58</identificador>
+                <mensaje>CLAVE ACCESO REGISTRADA</mensaje>
+                <tipo>ERROR</tipo>
+              </mensaje>
+            </mensajes>
+          </autorizacion>
+        </autorizaciones>
+      </RespuestaAutorizacionComprobante>
+    </ns2:autorizacionComprobanteResponse>
+  </soap:Body>
+</soap:Envelope>`;
+
+const respuestaEnProceso = `<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <ns2:autorizacionComprobanteResponse xmlns:ns2="http://ec.gob.sri.ws.autorizacion">
+      <RespuestaAutorizacionComprobante>
+        <claveAccesoConsultada>${CLAVE_ACCESO}</claveAccesoConsultada>
+        <numeroComprobantes>0</numeroComprobantes>
+        <autorizaciones/>
+      </RespuestaAutorizacionComprobante>
+    </ns2:autorizacionComprobanteResponse>
+  </soap:Body>
+</soap:Envelope>`;
+
+describe('autorizarComprobanteSRI', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('parses an AUTORIZADO response', async () => {
+    axiosMock.post.mockResolvedValueOnce({ data: respuestaAutorizado } as any);
+
+    const resultado = await autorizarComprobanteSRI(CLAVE_ACCESO);
+
+    expect(resultado.estado).toBe('AUTORIZADO');
+    expect(resultado.numeroAutorizacion).toBe(CLAVE_ACCESO);
+    expect(resultado.fechaAutorizacion).toBe('2025-05-17T12:00:00-05:00');
+    expect(resultado.ambiente).toBe('PRUEBAS');
+  });
+
+  it('sends the claveAcceso to the authorization SOAP service', async () => {
+    axiosMock.post.mockResolvedValueOnce({ data: respuestaAutorizado } as any);
+
+    await autorizarComprobanteSRI(CLAVE_ACCESO);
+
+    const [url, body] = axiosMock.post.mock.calls[0];
+    expect(url).toContain('AutorizacionComprobantesOffline');
+    expect(body).toContain(`<claveAccesoComprobante>${CLAVE_ACCESO}</claveAccesoComprobante>`);
+    expect(body).toContain('http://ec.gob.sri.ws.autorizacion');
+  });
+
+  it('parses a NO AUTORIZADO response with its mensajes', async () => {
+    axiosMock.post.mockResolvedValueOnce({ data: respuestaNoAutorizado } as any);
+
+    const resultado = await autorizarComprobanteSRI(CLAVE_ACCESO);
+
+    expect(resultado.estado).toBe('NO AUTORIZADO');
+    expect(resultado.mensajes).toBeDefined();
+    expect((resultado.mensajes as any).mensaje.identificador).toBe('58');
+  });
+
+  it('returns EN PROCESO when the SRI has not resolved the receipt yet', async () => {
+    axiosMock.post.mockResolvedValueOnce({ data: respuestaEnProceso } as any);
+
+    const resultado = await autorizarComprobanteSRI(CLAVE_ACCESO);
+
+    expect(resultado.estado).toBe('EN PROCESO');
+  });
+
+  it('returns ERROR_COMUNICACION when the service is unreachable', async () => {
+    axiosMock.post.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const resultado = await autorizarComprobanteSRI(CLAVE_ACCESO);
+
+    expect(resultado.estado).toBe('ERROR_COMUNICACION');
+  });
+});

--- a/__tests__/utils/sri.recepcion.test.ts
+++ b/__tests__/utils/sri.recepcion.test.ts
@@ -1,0 +1,117 @@
+import axios from 'axios';
+import { enviarComprobanteSRI } from '../../src/utils/sri.utils';
+
+jest.mock('axios');
+const axiosMock = axios as jest.Mocked<typeof axios>;
+
+const XML_FIRMADO = '<factura id="comprobante">firmada</factura>';
+
+const respuestaRecibida = `<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <ns2:validarComprobanteResponse xmlns:ns2="http://ec.gob.sri.ws.recepcion">
+      <RespuestaRecepcionComprobante>
+        <estado>RECIBIDA</estado>
+        <comprobantes/>
+      </RespuestaRecepcionComprobante>
+    </ns2:validarComprobanteResponse>
+  </soap:Body>
+</soap:Envelope>`;
+
+const respuestaDevuelta = `<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <ns2:validarComprobanteResponse xmlns:ns2="http://ec.gob.sri.ws.recepcion">
+      <RespuestaRecepcionComprobante>
+        <estado>DEVUELTA</estado>
+        <comprobantes>
+          <comprobante>
+            <claveAcceso>1705202501179001234500110010010000000011234567810</claveAcceso>
+            <mensajes>
+              <mensaje>
+                <identificador>35</identificador>
+                <mensaje>ARCHIVO NO CUMPLE ESTRUCTURA XML</mensaje>
+                <informacionAdicional>detalle del error</informacionAdicional>
+                <tipo>ERROR</tipo>
+              </mensaje>
+            </mensajes>
+          </comprobante>
+        </comprobantes>
+      </RespuestaRecepcionComprobante>
+    </ns2:validarComprobanteResponse>
+  </soap:Body>
+</soap:Envelope>`;
+
+const respuestaSoapFault = `<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <soap:Fault>
+      <faultcode>soap:Client</faultcode>
+      <faultstring>Cannot process request</faultstring>
+    </soap:Fault>
+  </soap:Body>
+</soap:Envelope>`;
+
+describe('enviarComprobanteSRI', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('parses a RECIBIDA response', async () => {
+    axiosMock.post.mockResolvedValueOnce({ data: respuestaRecibida } as any);
+
+    const resultado = await enviarComprobanteSRI(XML_FIRMADO);
+
+    expect(resultado.estado).toBe('RECIBIDA');
+  });
+
+  it('sends the signed XML as base64 to the recepción service', async () => {
+    axiosMock.post.mockResolvedValueOnce({ data: respuestaRecibida } as any);
+
+    await enviarComprobanteSRI(XML_FIRMADO);
+
+    const [url, body] = axiosMock.post.mock.calls[0];
+    expect(url).toContain('RecepcionComprobantesOffline');
+    expect(body).toContain(Buffer.from(XML_FIRMADO).toString('base64'));
+    expect(body).toContain('validarComprobante');
+  });
+
+  it('parses a DEVUELTA response with mensajes and comprobantes', async () => {
+    axiosMock.post.mockResolvedValueOnce({ data: respuestaDevuelta } as any);
+
+    const resultado = await enviarComprobanteSRI(XML_FIRMADO);
+
+    expect(resultado.estado).toBe('DEVUELTA');
+    expect(resultado.mensajes).toBeDefined();
+    expect((resultado.mensajes as any).mensaje.identificador).toBe('35');
+    expect((resultado.mensajes as any).mensaje.informacionAdicional).toBe('detalle del error');
+    expect(resultado.comprobantes?.comprobante?.[0].claveAcceso).toContain('1705202501');
+  });
+
+  it('tries the next SOAPAction when the first returns a SOAP fault', async () => {
+    axiosMock.post
+      .mockResolvedValueOnce({ data: respuestaSoapFault } as any)
+      .mockResolvedValueOnce({ data: respuestaRecibida } as any);
+
+    const resultado = await enviarComprobanteSRI(XML_FIRMADO);
+
+    expect(resultado.estado).toBe('RECIBIDA');
+    expect(axiosMock.post).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns ERROR_COMUNICACION when every SOAPAction fails', async () => {
+    axiosMock.post.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const resultado = await enviarComprobanteSRI(XML_FIRMADO);
+
+    expect(resultado.estado).toBe('ERROR_COMUNICACION');
+  });
+
+  it('returns ERROR_COMUNICACION when the response is not a string', async () => {
+    axiosMock.post.mockResolvedValue({ data: { unexpected: true } } as any);
+
+    const resultado = await enviarComprobanteSRI(XML_FIRMADO);
+
+    expect(resultado.estado).toBe('ERROR_COMUNICACION');
+  });
+});

--- a/__tests__/utils/withholding.utils.test.ts
+++ b/__tests__/utils/withholding.utils.test.ts
@@ -150,9 +150,11 @@ describe('generarXMLRetencion', () => {
     expect(xml).toContain('<valorRetenido>10.50</valorRetenido>');
   });
 
-  it('includes the pagos block with the ATS formapago tag', () => {
-    // El Anexo 10 del ATS 2.0.0 usa la etiqueta <formapago> en minúscula
-    expect(xml).toContain('<formapago>01</formapago>');
+  it('includes the pagos block with the formaPago tag (camelCase per SRI XSD)', () => {
+    // El ejemplo del Anexo 10 muestra <formapago> en minúscula, pero el XSD real del SRI
+    // valida <formaPago> (el SRI devuelve error 35 con la variante en minúscula)
+    expect(xml).toContain('<formaPago>01</formaPago>');
+    expect(xml).not.toContain('<formapago>');
     expect(xml).toContain('<total>115.00</total>');
   });
 

--- a/__tests__/utils/withholding.utils.test.ts
+++ b/__tests__/utils/withholding.utils.test.ts
@@ -1,0 +1,167 @@
+import { generarXMLRetencion } from '../../src/utils/xml.utils';
+import { generarClaveAcceso, obtenerDigitoVerificador } from '../../src/utils/invoice.utils';
+import { WithholdingRequest } from '../../src/interfaces/withholding.interface';
+
+const empresaMock: any = {
+  tipo_ambiente: 1,
+  tipo_emision: 1,
+  razon_social: 'EMPRESA DEMO S.A.',
+  nombre_comercial: 'DEMO',
+  ruc: '1790012345001',
+  codigo_establecimiento: '001',
+  punto_emision: '001',
+  direccion_matriz: 'Av. Principal 123',
+  direccion_establecimiento: 'Av. Principal 123',
+  obligado_contabilidad: true,
+};
+
+const retencionMock: WithholdingRequest = {
+  infoTributaria: { ruc: '1790012345001', claveAcceso: '', secuencial: '' },
+  infoCompRetencion: {
+    fechaEmision: '17/05/2025',
+    tipoIdentificacionSujetoRetenido: '04',
+    parteRel: 'NO',
+    razonSocialSujetoRetenido: 'Proveedor S.A.',
+    identificacionSujetoRetenido: '1713328506001',
+    periodoFiscal: '05/2025',
+  },
+  docsSustento: [
+    {
+      docSustento: {
+        codSustento: '01',
+        codDocSustento: '01',
+        numDocSustento: '001001000000123',
+        fechaEmisionDocSustento: '10/05/2025',
+        numAutDocSustento: '1005202501179001234500110010010000001231234567818',
+        pagoLocExt: '01',
+        totalSinImpuestos: '100.00',
+        importeTotal: '115.00',
+        impuestosDocSustento: [
+          {
+            impuestoDocSustento: {
+              codImpuestoDocSustento: '2',
+              codigoPorcentaje: '4',
+              baseImponible: '100.00',
+              tarifa: '15',
+              valorImpuesto: '15.00',
+            },
+          },
+        ],
+        retenciones: [
+          {
+            retencion: {
+              codigo: '1',
+              codigoRetencion: '312',
+              baseImponible: '100.00',
+              porcentajeRetener: '1.75',
+              valorRetenido: '1.75',
+            },
+          },
+          {
+            retencion: {
+              codigo: '2',
+              codigoRetencion: '3',
+              baseImponible: '15.00',
+              porcentajeRetener: '70',
+              valorRetenido: '10.50',
+            },
+          },
+        ],
+        pagos: [
+          {
+            pago: {
+              formaPago: '01',
+              total: '115.00',
+            },
+          },
+        ],
+      },
+    },
+  ],
+};
+
+describe('generarClaveAcceso for withholding certificates', () => {
+  it('generates a 49-digit access key with document type 07', () => {
+    const clave = generarClaveAcceso({
+      fecha: new Date(Date.UTC(2025, 4, 17)),
+      tipoComprobante: '07',
+      ruc: '1790012345001',
+      ambiente: '1',
+      serie: '001001',
+      secuencial: '000000001',
+      codigoNumerico: '12345678',
+      tipoEmision: '1',
+    });
+
+    expect(clave).toHaveLength(49);
+    expect(clave.substring(8, 10)).toBe('07');
+    expect(clave[48]).toBe(obtenerDigitoVerificador(clave.substring(0, 48)));
+  });
+});
+
+describe('generarXMLRetencion', () => {
+  const xml = generarXMLRetencion(
+    retencionMock,
+    empresaMock,
+    '1705202507179001234500110010010000000011234567810',
+    '000000001',
+  );
+
+  it('generates the comprobanteRetencion root with version 2.0.0 and id comprobante', () => {
+    expect(xml).toContain('<comprobanteRetencion id="comprobante" version="2.0.0">');
+  });
+
+  it('uses codDoc 07', () => {
+    expect(xml).toContain('<codDoc>07</codDoc>');
+  });
+
+  it('includes the infoCompRetencion fields', () => {
+    expect(xml).toContain('<tipoIdentificacionSujetoRetenido>04</tipoIdentificacionSujetoRetenido>');
+    expect(xml).toContain('<parteRel>NO</parteRel>');
+    expect(xml).toContain('<razonSocialSujetoRetenido>Proveedor S.A.</razonSocialSujetoRetenido>');
+    expect(xml).toContain('<identificacionSujetoRetenido>1713328506001</identificacionSujetoRetenido>');
+    expect(xml).toContain('<periodoFiscal>05/2025</periodoFiscal>');
+  });
+
+  it('omits tipoSujetoRetenido when not provided', () => {
+    expect(xml).not.toContain('<tipoSujetoRetenido>');
+  });
+
+  it('includes the docSustento with its catalog codes and totals', () => {
+    expect(xml).toContain('<codSustento>01</codSustento>');
+    expect(xml).toContain('<codDocSustento>01</codDocSustento>');
+    expect(xml).toContain('<numDocSustento>001001000000123</numDocSustento>');
+    expect(xml).toContain('<pagoLocExt>01</pagoLocExt>');
+    expect(xml).toContain('<totalSinImpuestos>100.00</totalSinImpuestos>');
+    expect(xml).toContain('<importeTotal>115.00</importeTotal>');
+  });
+
+  it('includes the impuestosDocSustento block', () => {
+    expect(xml).toContain('<codImpuestoDocSustento>2</codImpuestoDocSustento>');
+    expect(xml).toContain('<valorImpuesto>15.00</valorImpuesto>');
+  });
+
+  it('includes every retencion with its codes and values', () => {
+    expect((xml.match(/<retencion>/g) || []).length).toBe(2);
+    expect(xml).toContain('<codigoRetencion>312</codigoRetencion>');
+    expect(xml).toContain('<porcentajeRetener>1.75</porcentajeRetener>');
+    expect(xml).toContain('<valorRetenido>1.75</valorRetenido>');
+    expect(xml).toContain('<codigoRetencion>3</codigoRetencion>');
+    expect(xml).toContain('<valorRetenido>10.50</valorRetenido>');
+  });
+
+  it('includes the pagos block with the ATS formapago tag', () => {
+    // El Anexo 10 del ATS 2.0.0 usa la etiqueta <formapago> en minúscula
+    expect(xml).toContain('<formapago>01</formapago>');
+    expect(xml).toContain('<total>115.00</total>');
+  });
+
+  it('nests the blocks inside docSustento in the required order', () => {
+    const docSustento = xml.substring(xml.indexOf('<docSustento>'), xml.indexOf('</docSustento>'));
+    expect(docSustento).toContain('<impuestosDocSustento>');
+    expect(docSustento).toContain('<retenciones>');
+    expect(docSustento).toContain('<pagos>');
+    expect(docSustento.indexOf('<impuestosDocSustento>')).toBeLessThan(docSustento.indexOf('<retenciones>'));
+    expect(docSustento.indexOf('<retenciones>')).toBeLessThan(docSustento.indexOf('<pagos>'));
+  });
+});

--- a/__tests__/withholding.routes.test.ts
+++ b/__tests__/withholding.routes.test.ts
@@ -1,0 +1,183 @@
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { createApp } from '../src/testApp';
+
+// --- Model mocks ---
+const withholdingInstanceMocks = {
+  save: jest.fn().mockResolvedValue({}),
+};
+
+const withholdingStaticMocks = {
+  find: jest.fn().mockResolvedValue([]),
+  findById: jest.fn().mockResolvedValue(null),
+  findOne: jest.fn().mockResolvedValue(null),
+  findByIdAndUpdate: jest.fn().mockResolvedValue(null),
+  findByIdAndDelete: jest.fn().mockResolvedValue(null),
+};
+
+jest.mock('../src/models/Withholding', () => {
+  class MockWithholding {
+    constructor(public data: any) {}
+    save = withholdingInstanceMocks.save;
+    static find = (...args: any[]) => withholdingStaticMocks.find(...args);
+    static findById = (...args: any[]) => withholdingStaticMocks.findById(...args);
+    static findOne = (...args: any[]) => withholdingStaticMocks.findOne(...args);
+    static findByIdAndUpdate = (...args: any[]) => withholdingStaticMocks.findByIdAndUpdate(...args);
+    static findByIdAndDelete = (...args: any[]) => withholdingStaticMocks.findByIdAndDelete(...args);
+  }
+  return { __esModule: true, default: MockWithholding };
+});
+
+const withholdingPDFStaticMocks = {
+  findOne: jest.fn().mockResolvedValue(null),
+};
+
+jest.mock('../src/models/WithholdingPDF', () => ({
+  __esModule: true,
+  default: {
+    findOne: (...args: any[]) => withholdingPDFStaticMocks.findOne(...args),
+  },
+}));
+
+// --- Service mock ---
+const crearRetencionCompletaMock = jest.fn();
+jest.mock('../src/services/withholding.service', () => ({
+  WithholdingService: {
+    crearRetencionCompleta: (...args: any[]) => crearRetencionCompletaMock(...args),
+  },
+}));
+
+const app = createApp();
+const token = jwt.sign({ userId: '1' }, process.env.JWT_SECRET as string);
+const authHeader = `Bearer ${token}`;
+
+const retencionPayload = {
+  infoTributaria: { ruc: '1790012345001' },
+  infoCompRetencion: {
+    fechaEmision: '17/05/2025',
+    tipoIdentificacionSujetoRetenido: '04',
+    razonSocialSujetoRetenido: 'Proveedor S.A.',
+    identificacionSujetoRetenido: '1713328506001',
+    periodoFiscal: '05/2025',
+  },
+  docsSustento: [],
+};
+
+describe('Withholding routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /api/v1/withholding/complete', () => {
+    it('requires authentication', async () => {
+      const res = await request(app).post('/api/v1/withholding/complete').send({});
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 400 when retencion is missing', async () => {
+      const res = await request(app).post('/api/v1/withholding/complete').set('Authorization', authHeader).send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(crearRetencionCompletaMock).not.toHaveBeenCalled();
+    });
+
+    it('creates a complete withholding and returns its XML', async () => {
+      const resultadoMock = {
+        retencion: { secuencial: '000000001', clave_acceso: '123' },
+        xml: '<comprobanteRetencion/>',
+        xml_firmado: null,
+        respuesta_sri: null,
+      };
+      crearRetencionCompletaMock.mockResolvedValueOnce(resultadoMock);
+
+      const res = await request(app)
+        .post('/api/v1/withholding/complete')
+        .set('Authorization', authHeader)
+        .send({ retencion: retencionPayload });
+
+      expect(res.status).toBe(201);
+      expect(res.body.success).toBe(true);
+      expect(res.body.xml).toBe('<comprobanteRetencion/>');
+      expect(crearRetencionCompletaMock).toHaveBeenCalledWith(retencionPayload);
+    });
+
+    it('returns 400 for validation errors from the service', async () => {
+      crearRetencionCompletaMock.mockRejectedValueOnce(
+        new Error('Datos de comprobante de retención inválidos o incompletos'),
+      );
+
+      const res = await request(app)
+        .post('/api/v1/withholding/complete')
+        .set('Authorization', authHeader)
+        .send({ retencion: retencionPayload });
+
+      expect(res.status).toBe(400);
+      expect(res.body.message).toContain('inválidos');
+    });
+
+    it('returns 500 for unexpected service errors', async () => {
+      crearRetencionCompletaMock.mockRejectedValueOnce(new Error('mongo down'));
+
+      const res = await request(app)
+        .post('/api/v1/withholding/complete')
+        .set('Authorization', authHeader)
+        .send({ retencion: retencionPayload });
+
+      expect(res.status).toBe(500);
+      expect(res.body.success).toBe(false);
+    });
+  });
+
+  describe('CRUD endpoints', () => {
+    it('lists withholdings', async () => {
+      withholdingStaticMocks.find.mockResolvedValueOnce([{ secuencial: '000000001' }]);
+
+      const res = await request(app).get('/api/v1/withholding').set('Authorization', authHeader);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+    });
+
+    it('returns 404 for a missing withholding', async () => {
+      const res = await request(app)
+        .get('/api/v1/withholding/507f1f77bcf86cd799439011')
+        .set('Authorization', authHeader);
+
+      expect(res.status).toBe(404);
+    });
+
+    it('returns a withholding by id', async () => {
+      withholdingStaticMocks.findById.mockResolvedValueOnce({ secuencial: '000000001' });
+
+      const res = await request(app)
+        .get('/api/v1/withholding/507f1f77bcf86cd799439011')
+        .set('Authorization', authHeader);
+
+      expect(res.status).toBe(200);
+      expect(res.body.secuencial).toBe('000000001');
+    });
+
+    it('returns the PDF info of a withholding', async () => {
+      withholdingPDFStaticMocks.findOne.mockResolvedValueOnce({ pdf_url: 'https://cdn/pdf.pdf', estado: 'GENERADO' });
+
+      const res = await request(app)
+        .get('/api/v1/withholding/507f1f77bcf86cd799439011/pdf')
+        .set('Authorization', authHeader);
+
+      expect(res.status).toBe(200);
+      expect(res.body.pdf_url).toBe('https://cdn/pdf.pdf');
+    });
+
+    it('deletes a withholding', async () => {
+      withholdingStaticMocks.findByIdAndDelete.mockResolvedValueOnce({ _id: '507f1f77bcf86cd799439011' });
+
+      const res = await request(app)
+        .delete('/api/v1/withholding/507f1f77bcf86cd799439011')
+        .set('Authorization', authHeader);
+
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Deleted');
+    });
+  });
+});

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,20 @@
+services:
+  mongo:
+    image: mongo
+    restart: always
+    ports:
+      - 27017:27017
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: example
+
+  mongo-express:
+    image: mongo-express
+    restart: always
+    ports:
+      - 8081:8081
+    environment:
+      ME_CONFIG_MONGODB_URL: mongodb://root:example@mongo:27017/
+      ME_CONFIG_BASICAUTH_ENABLED: true
+      ME_CONFIG_BASICAUTH_USERNAME: mongoexpressuser
+      ME_CONFIG_BASICAUTH_PASSWORD: mongoexpresspass

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,10 +16,10 @@ module.exports = {
   coverageReporters: ['text', 'lcov', 'html'],
   coverageThreshold: {
     global: {
-      branches: 15,
-      functions: 30,
-      lines: 35,
-      statements: 35
+      branches: 70,
+      functions: 90,
+      lines: 85,
+      statements: 85
     }
   },
   setupFilesAfterEnv: ['<rootDir>/__tests__/setup.ts'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "cloudinary": "^2.5.1",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
+        "ec-sri-invoice-signer": "^1.8.1",
         "express": "^4.18.2",
         "jsbarcode": "^3.11.6",
         "jsonwebtoken": "^9.0.0",
@@ -1326,6 +1327,18 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@oozcitak/dom": {
       "version": "1.15.10",
       "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-1.15.10.tgz",
@@ -2033,6 +2046,18 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/arg": {
       "version": "4.1.3",
@@ -3048,6 +3073,27 @@
         "xtend": "^4.0.0"
       }
     },
+    "node_modules/ec-sri-invoice-signer": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/ec-sri-invoice-signer/-/ec-sri-invoice-signer-1.8.1.tgz",
+      "integrity": "sha512-oD8Rh6+0ZMH5hoqTofJZp26ZAiwwei5oKU7TlnWgi7qtw6J+vumm0Kab4jRo9P/dGjgGVhbc7pfWjZmNXa8tVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.9.10",
+        "fast-xml-parser": "^5.5.9",
+        "node-forge": "^1.3.3",
+        "xml-crypto": "^6.1.2"
+      }
+    },
+    "node_modules/ec-sri-invoice-signer/node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -3725,6 +3771,45 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+      "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.3.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -4525,6 +4610,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-unsafe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -5906,9 +6003,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
@@ -6284,6 +6381,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-is-absolute": {
@@ -7218,6 +7330,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
+    },
     "node_modules/superagent": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
@@ -7939,6 +8066,21 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlbuilder2": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,9 +33,9 @@
       "devDependencies": {
         "@types/bcryptjs": "^2.4.2",
         "@types/express": "^4.17.17",
-        "@types/jest": "^29.5.2",
+        "@types/jest": "^29.5.14",
         "@types/jsonwebtoken": "^9.0.2",
-        "@types/node": "^20.1.5",
+        "@types/node": "^20.19.43",
         "@types/node-forge": "^1.3.11",
         "@types/supertest": "^2.0.12",
         "eslint-config-prettier": "^10.1.5",
@@ -1739,12 +1739,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.17.47",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.47.tgz",
-      "integrity": "sha512-3dLX0Upo1v7RvUimvxLeXqwrfyKxUINk0EAM83swP2mlSUcwV73sZy8XhNz8bcZ3VbsfQyC/y6jRdL5tgCNpDQ==",
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/node-forge": {
@@ -7841,9 +7841,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "cloudinary": "^2.5.1",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
+    "ec-sri-invoice-signer": "^1.8.1",
     "express": "^4.18.2",
     "jsbarcode": "^3.11.6",
     "jsonwebtoken": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "F Sri - Sistema de facturación electrónica para Ecuador con integración al SRI",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "start": "node dist/index.js",
     "dev": "nodemon src/index.ts",
     "test": "jest",
@@ -66,9 +66,9 @@
   "devDependencies": {
     "@types/bcryptjs": "^2.4.2",
     "@types/express": "^4.17.17",
-    "@types/jest": "^29.5.2",
+    "@types/jest": "^29.5.14",
     "@types/jsonwebtoken": "^9.0.2",
-    "@types/node": "^20.1.5",
+    "@types/node": "^20.19.43",
     "@types/node-forge": "^1.3.11",
     "@types/supertest": "^2.0.12",
     "eslint-config-prettier": "^10.1.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import clientRoutes from './routes/client';
 import productRoutes from './routes/product';
 import invoiceRoutes from './routes/invoice';
 import creditNoteRoutes from './routes/creditNote';
+import debitNoteRoutes from './routes/debitNote';
 import invoiceDetailRoutes from './routes/invoiceDetail';
 import invoicePDFRoutes from './routes/invoicePDF';
 import verifyToken from './middleware/verifyToken';
@@ -94,6 +95,7 @@ app.use('/api/v1/client', clientRoutes);
 app.use('/api/v1/product', productRoutes);
 app.use('/api/v1/invoice', invoiceRoutes);
 app.use('/api/v1/credit-note', creditNoteRoutes);
+app.use('/api/v1/debit-note', debitNoteRoutes);
 app.use('/api/v1/invoice-detail', invoiceDetailRoutes);
 app.use('/api/v1/invoice-pdf', invoicePDFRoutes);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import productRoutes from './routes/product';
 import invoiceRoutes from './routes/invoice';
 import creditNoteRoutes from './routes/creditNote';
 import debitNoteRoutes from './routes/debitNote';
+import deliveryNoteRoutes from './routes/deliveryNote';
 import invoiceDetailRoutes from './routes/invoiceDetail';
 import invoicePDFRoutes from './routes/invoicePDF';
 import verifyToken from './middleware/verifyToken';
@@ -96,6 +97,7 @@ app.use('/api/v1/product', productRoutes);
 app.use('/api/v1/invoice', invoiceRoutes);
 app.use('/api/v1/credit-note', creditNoteRoutes);
 app.use('/api/v1/debit-note', debitNoteRoutes);
+app.use('/api/v1/delivery-note', deliveryNoteRoutes);
 app.use('/api/v1/invoice-detail', invoiceDetailRoutes);
 app.use('/api/v1/invoice-pdf', invoicePDFRoutes);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
 import express from 'express';
 import mongoose from 'mongoose';
-import dotenv from 'dotenv';
 import cors from 'cors';
 import { getCorsConfig } from './config/cors.config';
 import swaggerSpec from './swagger';
@@ -19,8 +22,6 @@ import invoiceDetailRoutes from './routes/invoiceDetail';
 import invoicePDFRoutes from './routes/invoicePDF';
 import verifyToken from './middleware/verifyToken';
 import corsErrorHandler from './middleware/corsErrorHandler';
-
-dotenv.config();
 
 const app = express();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import invoiceRoutes from './routes/invoice';
 import creditNoteRoutes from './routes/creditNote';
 import debitNoteRoutes from './routes/debitNote';
 import deliveryNoteRoutes from './routes/deliveryNote';
+import withholdingRoutes from './routes/withholding';
 import invoiceDetailRoutes from './routes/invoiceDetail';
 import invoicePDFRoutes from './routes/invoicePDF';
 import verifyToken from './middleware/verifyToken';
@@ -98,6 +99,7 @@ app.use('/api/v1/invoice', invoiceRoutes);
 app.use('/api/v1/credit-note', creditNoteRoutes);
 app.use('/api/v1/debit-note', debitNoteRoutes);
 app.use('/api/v1/delivery-note', deliveryNoteRoutes);
+app.use('/api/v1/withholding', withholdingRoutes);
 app.use('/api/v1/invoice-detail', invoiceDetailRoutes);
 app.use('/api/v1/invoice-pdf', invoicePDFRoutes);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import issuingCompanyRoutes from './routes/issuingCompany';
 import clientRoutes from './routes/client';
 import productRoutes from './routes/product';
 import invoiceRoutes from './routes/invoice';
+import creditNoteRoutes from './routes/creditNote';
 import invoiceDetailRoutes from './routes/invoiceDetail';
 import invoicePDFRoutes from './routes/invoicePDF';
 import verifyToken from './middleware/verifyToken';
@@ -92,6 +93,7 @@ app.use('/api/v1/issuing-company', issuingCompanyRoutes);
 app.use('/api/v1/client', clientRoutes);
 app.use('/api/v1/product', productRoutes);
 app.use('/api/v1/invoice', invoiceRoutes);
+app.use('/api/v1/credit-note', creditNoteRoutes);
 app.use('/api/v1/invoice-detail', invoiceDetailRoutes);
 app.use('/api/v1/invoice-pdf', invoicePDFRoutes);
 

--- a/src/interfaces/credit-note.interface.ts
+++ b/src/interfaces/credit-note.interface.ts
@@ -1,0 +1,70 @@
+import { TaxInfo } from './invoice.interface';
+
+/**
+ * Detalle de una nota de crédito según la Ficha Técnica del SRI (formato XML v1.1.0).
+ * A diferencia de la factura, el detalle usa codigoInterno / codigoAdicional.
+ */
+export interface CreditNoteProductDetail {
+  detalle: {
+    codigoInterno: string;
+    codigoAdicional?: string;
+    descripcion: string;
+    cantidad: string;
+    precioUnitario: string;
+    descuento?: string;
+    precioTotalSinImpuesto: string;
+    impuestos: Array<{
+      impuesto: {
+        codigo: string;
+        codigoPorcentaje: string;
+        tarifa: string;
+        baseImponible: string;
+        valor: string;
+      };
+    }>;
+  };
+}
+
+/**
+ * Información propia de la nota de crédito (nodo infoNotaCredito)
+ */
+export interface CreditNoteInfo {
+  fechaEmision: string;
+  tipoIdentificacionComprador: string;
+  identificacionComprador: string;
+  razonSocialComprador?: string;
+  /** Código del documento que se modifica (tabla 3). Normalmente '01' (factura) */
+  codDocModificado: string;
+  /** Número del documento que se modifica, formato 001-001-000000001 */
+  numDocModificado: string;
+  /** Fecha de emisión del documento de sustento, formato dd/mm/aaaa */
+  fechaEmisionDocSustento: string;
+  totalSinImpuestos: string;
+  /** Valor total de la modificación (incluye impuestos) */
+  valorModificacion: string;
+  moneda?: string;
+  /** Razón de la modificación, ej. DEVOLUCIÓN */
+  motivo: string;
+}
+
+export interface CreditNoteRequest {
+  infoTributaria: TaxInfo;
+  infoNotaCredito: CreditNoteInfo;
+  detalles: CreditNoteProductDetail[];
+}
+
+export interface CreateCreditNoteDTO {
+  empresaId: string | any;
+  clienteId: string | any;
+  facturaModificadaId?: string | any;
+  fechaEmision: Date;
+  claveAcceso: string;
+  secuencial: string;
+  codDocModificado: string;
+  numDocModificado: string;
+  fechaEmisionDocSustento: Date;
+  totalSinImpuestos: number;
+  totalIva: number;
+  valorModificacion: number;
+  motivo: string;
+}

--- a/src/interfaces/debit-note.interface.ts
+++ b/src/interfaces/debit-note.interface.ts
@@ -1,0 +1,63 @@
+import { TaxInfo } from './invoice.interface';
+
+/**
+ * Impuesto de una nota de débito (tabla 16/17 de la Ficha Técnica del SRI)
+ */
+export interface DebitNoteTax {
+  impuesto: {
+    codigo: string;
+    codigoPorcentaje: string;
+    tarifa: string;
+    baseImponible: string;
+    valor: string;
+  };
+}
+
+/**
+ * Pago de una nota de débito (formaPago según tabla 24 de la Ficha Técnica)
+ */
+export interface DebitNotePayment {
+  pago: {
+    formaPago: string;
+    total: string;
+    plazo?: string;
+    unidadTiempo?: string;
+  };
+}
+
+/**
+ * Motivo (recargo) de una nota de débito
+ */
+export interface DebitNoteReason {
+  motivo: {
+    razon: string;
+    valor: string;
+  };
+}
+
+/**
+ * Información propia de la nota de débito (nodo infoNotaDebito)
+ */
+export interface DebitNoteInfo {
+  fechaEmision: string;
+  tipoIdentificacionComprador: string;
+  identificacionComprador: string;
+  razonSocialComprador?: string;
+  /** Código del documento que se modifica (tabla 3). Normalmente '01' (factura) */
+  codDocModificado: string;
+  /** Número del documento que se modifica, formato 001-001-000000001 */
+  numDocModificado: string;
+  /** Fecha de emisión del documento de sustento, formato dd/mm/aaaa */
+  fechaEmisionDocSustento: string;
+  totalSinImpuestos: string;
+  impuestos: DebitNoteTax[];
+  /** Valor total de la nota de débito (base + impuestos) */
+  valorTotal: string;
+  pagos: DebitNotePayment[];
+}
+
+export interface DebitNoteRequest {
+  infoTributaria: TaxInfo;
+  infoNotaDebito: DebitNoteInfo;
+  motivos: DebitNoteReason[];
+}

--- a/src/interfaces/delivery-note.interface.ts
+++ b/src/interfaces/delivery-note.interface.ts
@@ -1,0 +1,58 @@
+import { TaxInfo } from './invoice.interface';
+
+/**
+ * Detalle de ítem trasladado en una guía de remisión.
+ * A diferencia de los demás comprobantes, no lleva precios ni impuestos.
+ */
+export interface DeliveryNoteItemDetail {
+  detalle: {
+    codigoInterno?: string;
+    codigoAdicional?: string;
+    descripcion: string;
+    /** Hasta 6 decimales (versión 1.1.0) */
+    cantidad: string;
+  };
+}
+
+/**
+ * Destinatario de la mercadería trasladada
+ */
+export interface DeliveryNoteRecipient {
+  destinatario: {
+    identificacionDestinatario: string;
+    razonSocialDestinatario: string;
+    dirDestinatario: string;
+    motivoTraslado: string;
+    docAduaneroUnico?: string;
+    codEstabDestino?: string;
+    ruta?: string;
+    /** Código del documento de sustento (tabla 3), ej. '01' factura */
+    codDocSustento?: string;
+    numDocSustento?: string;
+    numAutDocSustento?: string;
+    fechaEmisionDocSustento?: string;
+    detalles: DeliveryNoteItemDetail[];
+  };
+}
+
+/**
+ * Información propia de la guía de remisión (nodo infoGuiaRemision)
+ */
+export interface DeliveryNoteInfo {
+  /** Fecha de emisión dd/mm/aaaa. Se usa para la clave de acceso; el XML v1.1.0 no la incluye */
+  fechaEmision: string;
+  dirPartida: string;
+  razonSocialTransportista: string;
+  /** Tabla 6 del SRI */
+  tipoIdentificacionTransportista: string;
+  rucTransportista: string;
+  fechaIniTransporte: string;
+  fechaFinTransporte: string;
+  placa: string;
+}
+
+export interface DeliveryNoteRequest {
+  infoTributaria: TaxInfo;
+  infoGuiaRemision: DeliveryNoteInfo;
+  destinatarios: DeliveryNoteRecipient[];
+}

--- a/src/interfaces/withholding.interface.ts
+++ b/src/interfaces/withholding.interface.ts
@@ -1,0 +1,84 @@
+import { TaxInfo } from './invoice.interface';
+
+/**
+ * Impuesto del documento de sustento (tablas 16-18 de la Ficha Técnica)
+ */
+export interface WithholdingSupportDocTax {
+  impuestoDocSustento: {
+    codImpuestoDocSustento: string;
+    codigoPorcentaje: string;
+    baseImponible: string;
+    tarifa: string;
+    valorImpuesto: string;
+  };
+}
+
+/**
+ * Retención practicada (código según tabla 19, codigoRetencion según tablas 20/21)
+ */
+export interface WithholdingTax {
+  retencion: {
+    codigo: string;
+    codigoRetencion: string;
+    baseImponible: string;
+    porcentajeRetener: string;
+    valorRetenido: string;
+  };
+}
+
+/**
+ * Pago del documento de sustento (formaPago según tabla 13 del Catálogo ATS)
+ */
+export interface WithholdingPayment {
+  pago: {
+    formaPago: string;
+    total: string;
+  };
+}
+
+/**
+ * Documento de sustento de la retención (nodo docSustento del ATS 2.0.0)
+ */
+export interface WithholdingSupportDoc {
+  docSustento: {
+    /** Tabla 5 del Catálogo ATS */
+    codSustento: string;
+    /** Tabla 4 del Catálogo ATS, ej. '01' factura */
+    codDocSustento: string;
+    /** Formato 001001000000001 (15 dígitos) */
+    numDocSustento?: string;
+    fechaEmisionDocSustento: string;
+    fechaRegistroContable?: string;
+    numAutDocSustento?: string;
+    /** Tabla 15 del Catálogo ATS. '01' = pago local */
+    pagoLocExt: string;
+    totalSinImpuestos: string;
+    importeTotal: string;
+    impuestosDocSustento: WithholdingSupportDocTax[];
+    retenciones: WithholdingTax[];
+    pagos: WithholdingPayment[];
+  };
+}
+
+/**
+ * Información propia del comprobante de retención (nodo infoCompRetencion)
+ */
+export interface WithholdingInfo {
+  fechaEmision: string;
+  /** Tabla 6 del SRI */
+  tipoIdentificacionSujetoRetenido: string;
+  /** Tabla 14 del Catálogo ATS. Obligatorio si la identificación es del exterior */
+  tipoSujetoRetenido?: string;
+  /** Parte relacionada SI/NO */
+  parteRel?: string;
+  razonSocialSujetoRetenido: string;
+  identificacionSujetoRetenido: string;
+  /** Formato mm/aaaa */
+  periodoFiscal: string;
+}
+
+export interface WithholdingRequest {
+  infoTributaria: TaxInfo;
+  infoCompRetencion: WithholdingInfo;
+  docsSustento: WithholdingSupportDoc[];
+}

--- a/src/models/CreditNote.ts
+++ b/src/models/CreditNote.ts
@@ -1,0 +1,55 @@
+import { Schema, model, Document, Types } from 'mongoose';
+
+export interface ICreditNote extends Document {
+  empresa_emisora_id: Types.ObjectId;
+  cliente_id: Types.ObjectId;
+  factura_modificada_id?: Types.ObjectId;
+  fecha_emision: Date;
+  clave_acceso: string;
+  secuencial: string;
+  estado: string;
+  cod_doc_modificado: string;
+  num_doc_modificado: string;
+  fecha_emision_doc_sustento: Date;
+  total_sin_impuestos: number;
+  total_iva: number;
+  valor_modificacion: number;
+  motivo: string;
+  xml: string;
+  xml_firmado: string;
+  autorizacion_numero: string;
+  fecha_autorizacion: Date;
+  sri_estado?: string;
+  sri_mensajes?: any;
+  sri_fecha_envio?: Date;
+  sri_fecha_respuesta?: Date;
+  datos_originales?: string;
+}
+
+const schema = new Schema<ICreditNote>({
+  empresa_emisora_id: { type: Schema.Types.ObjectId, ref: 'IssuingCompany', required: true },
+  cliente_id: { type: Schema.Types.ObjectId, ref: 'Client', required: true },
+  factura_modificada_id: { type: Schema.Types.ObjectId, ref: 'Invoice' },
+  fecha_emision: { type: Date, required: true },
+  clave_acceso: { type: String, required: true },
+  secuencial: { type: String, required: true },
+  estado: { type: String, required: true },
+  cod_doc_modificado: { type: String, required: true },
+  num_doc_modificado: { type: String, required: true },
+  fecha_emision_doc_sustento: { type: Date, required: true },
+  total_sin_impuestos: { type: Number, required: true },
+  total_iva: { type: Number, required: true },
+  valor_modificacion: { type: Number, required: true },
+  motivo: { type: String, required: true },
+  xml: { type: String },
+  xml_firmado: { type: String },
+  autorizacion_numero: { type: String },
+  fecha_autorizacion: { type: Date },
+  sri_estado: { type: String },
+  sri_mensajes: { type: Schema.Types.Mixed },
+  sri_fecha_envio: { type: Date },
+  sri_fecha_respuesta: { type: Date },
+  datos_originales: { type: String },
+});
+
+export default model<ICreditNote>('CreditNote', schema);

--- a/src/models/CreditNoteDetail.ts
+++ b/src/models/CreditNoteDetail.ts
@@ -1,0 +1,21 @@
+import { Schema, model, Document, Types } from 'mongoose';
+
+export interface ICreditNoteDetail extends Document {
+  nota_credito_id: Types.ObjectId;
+  producto_id: Types.ObjectId;
+  cantidad: number;
+  precio_unitario: number;
+  subtotal: number;
+  valor_iva: number;
+}
+
+const schema = new Schema<ICreditNoteDetail>({
+  nota_credito_id: { type: Schema.Types.ObjectId, ref: 'CreditNote', required: true },
+  producto_id: { type: Schema.Types.ObjectId, ref: 'Product', required: true },
+  cantidad: { type: Number, required: true },
+  precio_unitario: { type: Number, required: true },
+  subtotal: { type: Number, required: true },
+  valor_iva: { type: Number, required: true },
+});
+
+export default model<ICreditNoteDetail>('CreditNoteDetail', schema);

--- a/src/models/CreditNotePDF.ts
+++ b/src/models/CreditNotePDF.ts
@@ -1,0 +1,40 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+/**
+ * PDF (RIDE) de una nota de crédito.
+ * Igual que InvoicePDF, no almacena el buffer: solo la URL pública del proveedor.
+ */
+export interface ICreditNotePDF extends Document {
+  nota_credito_id: string;
+  claveAcceso: string;
+
+  pdf_url: string;
+  pdf_public_id: string;
+  pdf_provider: string;
+
+  fecha_generacion: Date;
+  estado: 'GENERADO' | 'ERROR';
+  tamano_archivo: number;
+  numero_autorizacion: string;
+  fecha_autorizacion: Date;
+}
+
+const CreditNotePDFSchema: Schema = new Schema({
+  nota_credito_id: { type: String, required: true, ref: 'CreditNote' },
+  claveAcceso: { type: String, required: true, unique: true },
+
+  pdf_url: { type: String },
+  pdf_public_id: { type: String },
+  pdf_provider: { type: String, default: 'local' },
+
+  fecha_generacion: { type: Date, default: Date.now },
+  estado: { type: String, enum: ['GENERADO', 'ERROR'], default: 'GENERADO' },
+  tamano_archivo: { type: Number, required: true, default: 0 },
+  numero_autorizacion: { type: String, required: true },
+  fecha_autorizacion: { type: Date, required: true },
+});
+
+CreditNotePDFSchema.index({ nota_credito_id: 1 });
+CreditNotePDFSchema.index({ pdf_public_id: 1 });
+
+export default mongoose.model<ICreditNotePDF>('CreditNotePDF', CreditNotePDFSchema);

--- a/src/models/DebitNote.ts
+++ b/src/models/DebitNote.ts
@@ -1,0 +1,60 @@
+import { Schema, model, Document, Types } from 'mongoose';
+
+export interface IDebitNote extends Document {
+  empresa_emisora_id: Types.ObjectId;
+  cliente_id: Types.ObjectId;
+  factura_modificada_id?: Types.ObjectId;
+  fecha_emision: Date;
+  clave_acceso: string;
+  secuencial: string;
+  estado: string;
+  cod_doc_modificado: string;
+  num_doc_modificado: string;
+  fecha_emision_doc_sustento: Date;
+  total_sin_impuestos: number;
+  total_impuestos: number;
+  valor_total: number;
+  motivos: Array<{ razon: string; valor: number }>;
+  xml: string;
+  xml_firmado: string;
+  autorizacion_numero: string;
+  fecha_autorizacion: Date;
+  sri_estado?: string;
+  sri_mensajes?: any;
+  sri_fecha_envio?: Date;
+  sri_fecha_respuesta?: Date;
+  datos_originales?: string;
+}
+
+const schema = new Schema<IDebitNote>({
+  empresa_emisora_id: { type: Schema.Types.ObjectId, ref: 'IssuingCompany', required: true },
+  cliente_id: { type: Schema.Types.ObjectId, ref: 'Client', required: true },
+  factura_modificada_id: { type: Schema.Types.ObjectId, ref: 'Invoice' },
+  fecha_emision: { type: Date, required: true },
+  clave_acceso: { type: String, required: true },
+  secuencial: { type: String, required: true },
+  estado: { type: String, required: true },
+  cod_doc_modificado: { type: String, required: true },
+  num_doc_modificado: { type: String, required: true },
+  fecha_emision_doc_sustento: { type: Date, required: true },
+  total_sin_impuestos: { type: Number, required: true },
+  total_impuestos: { type: Number, required: true },
+  valor_total: { type: Number, required: true },
+  motivos: [
+    {
+      razon: { type: String, required: true },
+      valor: { type: Number, required: true },
+    },
+  ],
+  xml: { type: String },
+  xml_firmado: { type: String },
+  autorizacion_numero: { type: String },
+  fecha_autorizacion: { type: Date },
+  sri_estado: { type: String },
+  sri_mensajes: { type: Schema.Types.Mixed },
+  sri_fecha_envio: { type: Date },
+  sri_fecha_respuesta: { type: Date },
+  datos_originales: { type: String },
+});
+
+export default model<IDebitNote>('DebitNote', schema);

--- a/src/models/DebitNotePDF.ts
+++ b/src/models/DebitNotePDF.ts
@@ -1,0 +1,40 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+/**
+ * PDF (RIDE) de una nota de débito.
+ * Igual que InvoicePDF, no almacena el buffer: solo la URL pública del proveedor.
+ */
+export interface IDebitNotePDF extends Document {
+  nota_debito_id: string;
+  claveAcceso: string;
+
+  pdf_url: string;
+  pdf_public_id: string;
+  pdf_provider: string;
+
+  fecha_generacion: Date;
+  estado: 'GENERADO' | 'ERROR';
+  tamano_archivo: number;
+  numero_autorizacion: string;
+  fecha_autorizacion: Date;
+}
+
+const DebitNotePDFSchema: Schema = new Schema({
+  nota_debito_id: { type: String, required: true, ref: 'DebitNote' },
+  claveAcceso: { type: String, required: true, unique: true },
+
+  pdf_url: { type: String },
+  pdf_public_id: { type: String },
+  pdf_provider: { type: String, default: 'local' },
+
+  fecha_generacion: { type: Date, default: Date.now },
+  estado: { type: String, enum: ['GENERADO', 'ERROR'], default: 'GENERADO' },
+  tamano_archivo: { type: Number, required: true, default: 0 },
+  numero_autorizacion: { type: String, required: true },
+  fecha_autorizacion: { type: Date, required: true },
+});
+
+DebitNotePDFSchema.index({ nota_debito_id: 1 });
+DebitNotePDFSchema.index({ pdf_public_id: 1 });
+
+export default mongoose.model<IDebitNotePDF>('DebitNotePDF', DebitNotePDFSchema);

--- a/src/models/DeliveryNote.ts
+++ b/src/models/DeliveryNote.ts
@@ -1,0 +1,53 @@
+import { Schema, model, Document, Types } from 'mongoose';
+
+export interface IDeliveryNote extends Document {
+  empresa_emisora_id: Types.ObjectId;
+  fecha_emision: Date;
+  clave_acceso: string;
+  secuencial: string;
+  estado: string;
+  dir_partida: string;
+  razon_social_transportista: string;
+  tipo_identificacion_transportista: string;
+  ruc_transportista: string;
+  fecha_ini_transporte: Date;
+  fecha_fin_transporte: Date;
+  placa: string;
+  destinatarios: any[];
+  xml: string;
+  xml_firmado: string;
+  autorizacion_numero: string;
+  fecha_autorizacion: Date;
+  sri_estado?: string;
+  sri_mensajes?: any;
+  sri_fecha_envio?: Date;
+  sri_fecha_respuesta?: Date;
+  datos_originales?: string;
+}
+
+const schema = new Schema<IDeliveryNote>({
+  empresa_emisora_id: { type: Schema.Types.ObjectId, ref: 'IssuingCompany', required: true },
+  fecha_emision: { type: Date, required: true },
+  clave_acceso: { type: String, required: true },
+  secuencial: { type: String, required: true },
+  estado: { type: String, required: true },
+  dir_partida: { type: String, required: true },
+  razon_social_transportista: { type: String, required: true },
+  tipo_identificacion_transportista: { type: String, required: true },
+  ruc_transportista: { type: String, required: true },
+  fecha_ini_transporte: { type: Date, required: true },
+  fecha_fin_transporte: { type: Date, required: true },
+  placa: { type: String, required: true },
+  destinatarios: { type: Schema.Types.Mixed, required: true },
+  xml: { type: String },
+  xml_firmado: { type: String },
+  autorizacion_numero: { type: String },
+  fecha_autorizacion: { type: Date },
+  sri_estado: { type: String },
+  sri_mensajes: { type: Schema.Types.Mixed },
+  sri_fecha_envio: { type: Date },
+  sri_fecha_respuesta: { type: Date },
+  datos_originales: { type: String },
+});
+
+export default model<IDeliveryNote>('DeliveryNote', schema);

--- a/src/models/DeliveryNotePDF.ts
+++ b/src/models/DeliveryNotePDF.ts
@@ -1,0 +1,40 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+/**
+ * PDF (RIDE) de una guía de remisión.
+ * Igual que InvoicePDF, no almacena el buffer: solo la URL pública del proveedor.
+ */
+export interface IDeliveryNotePDF extends Document {
+  guia_remision_id: string;
+  claveAcceso: string;
+
+  pdf_url: string;
+  pdf_public_id: string;
+  pdf_provider: string;
+
+  fecha_generacion: Date;
+  estado: 'GENERADO' | 'ERROR';
+  tamano_archivo: number;
+  numero_autorizacion: string;
+  fecha_autorizacion: Date;
+}
+
+const DeliveryNotePDFSchema: Schema = new Schema({
+  guia_remision_id: { type: String, required: true, ref: 'DeliveryNote' },
+  claveAcceso: { type: String, required: true, unique: true },
+
+  pdf_url: { type: String },
+  pdf_public_id: { type: String },
+  pdf_provider: { type: String, default: 'local' },
+
+  fecha_generacion: { type: Date, default: Date.now },
+  estado: { type: String, enum: ['GENERADO', 'ERROR'], default: 'GENERADO' },
+  tamano_archivo: { type: Number, required: true, default: 0 },
+  numero_autorizacion: { type: String, required: true },
+  fecha_autorizacion: { type: Date, required: true },
+});
+
+DeliveryNotePDFSchema.index({ guia_remision_id: 1 });
+DeliveryNotePDFSchema.index({ pdf_public_id: 1 });
+
+export default mongoose.model<IDeliveryNotePDF>('DeliveryNotePDF', DeliveryNotePDFSchema);

--- a/src/models/Withholding.ts
+++ b/src/models/Withholding.ts
@@ -1,0 +1,49 @@
+import { Schema, model, Document, Types } from 'mongoose';
+
+export interface IWithholding extends Document {
+  empresa_emisora_id: Types.ObjectId;
+  fecha_emision: Date;
+  clave_acceso: string;
+  secuencial: string;
+  estado: string;
+  tipo_identificacion_sujeto_retenido: string;
+  razon_social_sujeto_retenido: string;
+  identificacion_sujeto_retenido: string;
+  periodo_fiscal: string;
+  total_retenido: number;
+  docs_sustento: any[];
+  xml: string;
+  xml_firmado: string;
+  autorizacion_numero: string;
+  fecha_autorizacion: Date;
+  sri_estado?: string;
+  sri_mensajes?: any;
+  sri_fecha_envio?: Date;
+  sri_fecha_respuesta?: Date;
+  datos_originales?: string;
+}
+
+const schema = new Schema<IWithholding>({
+  empresa_emisora_id: { type: Schema.Types.ObjectId, ref: 'IssuingCompany', required: true },
+  fecha_emision: { type: Date, required: true },
+  clave_acceso: { type: String, required: true },
+  secuencial: { type: String, required: true },
+  estado: { type: String, required: true },
+  tipo_identificacion_sujeto_retenido: { type: String, required: true },
+  razon_social_sujeto_retenido: { type: String, required: true },
+  identificacion_sujeto_retenido: { type: String, required: true },
+  periodo_fiscal: { type: String, required: true },
+  total_retenido: { type: Number, required: true },
+  docs_sustento: { type: Schema.Types.Mixed, required: true },
+  xml: { type: String },
+  xml_firmado: { type: String },
+  autorizacion_numero: { type: String },
+  fecha_autorizacion: { type: Date },
+  sri_estado: { type: String },
+  sri_mensajes: { type: Schema.Types.Mixed },
+  sri_fecha_envio: { type: Date },
+  sri_fecha_respuesta: { type: Date },
+  datos_originales: { type: String },
+});
+
+export default model<IWithholding>('Withholding', schema);

--- a/src/models/WithholdingPDF.ts
+++ b/src/models/WithholdingPDF.ts
@@ -1,0 +1,40 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+/**
+ * PDF (RIDE) de un comprobante de retención.
+ * Igual que InvoicePDF, no almacena el buffer: solo la URL pública del proveedor.
+ */
+export interface IWithholdingPDF extends Document {
+  retencion_id: string;
+  claveAcceso: string;
+
+  pdf_url: string;
+  pdf_public_id: string;
+  pdf_provider: string;
+
+  fecha_generacion: Date;
+  estado: 'GENERADO' | 'ERROR';
+  tamano_archivo: number;
+  numero_autorizacion: string;
+  fecha_autorizacion: Date;
+}
+
+const WithholdingPDFSchema: Schema = new Schema({
+  retencion_id: { type: String, required: true, ref: 'Withholding' },
+  claveAcceso: { type: String, required: true, unique: true },
+
+  pdf_url: { type: String },
+  pdf_public_id: { type: String },
+  pdf_provider: { type: String, default: 'local' },
+
+  fecha_generacion: { type: Date, default: Date.now },
+  estado: { type: String, enum: ['GENERADO', 'ERROR'], default: 'GENERADO' },
+  tamano_archivo: { type: Number, required: true, default: 0 },
+  numero_autorizacion: { type: String, required: true },
+  fecha_autorizacion: { type: Date, required: true },
+});
+
+WithholdingPDFSchema.index({ retencion_id: 1 });
+WithholdingPDFSchema.index({ pdf_public_id: 1 });
+
+export default mongoose.model<IWithholdingPDF>('WithholdingPDF', WithholdingPDFSchema);

--- a/src/routes/creditNote.ts
+++ b/src/routes/creditNote.ts
@@ -1,0 +1,111 @@
+import { Router } from 'express';
+import CreditNote from '../models/CreditNote';
+import CreditNotePDF from '../models/CreditNotePDF';
+import { CreditNoteService } from '../services/credit-note.service';
+
+const router = Router();
+
+router.post('/', async (req, res) => {
+  try {
+    const doc = new CreditNote(req.body);
+    await doc.save();
+    res.status(201).json(doc);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.post('/complete', async (req, res) => {
+  try {
+    if (!req.body.nota_credito) {
+      return res.status(400).json({
+        success: false,
+        message: 'Credit note data is required',
+      });
+    }
+
+    const resultado = await CreditNoteService.crearNotaCreditoCompleta(req.body.nota_credito);
+
+    return res.status(201).json({
+      success: true,
+      data: resultado,
+      xml: resultado.xml,
+    });
+  } catch (err: any) {
+    // Errors that should return 400 (Bad Request)
+    const validationErrors = [
+      'Product not found',
+      'Client not found',
+      'Identification type not found',
+      'Empresa emisora no encontrada',
+      'Invalid date format',
+      'Datos de nota de crédito inválidos o incompletos',
+    ];
+
+    const isValidationError = validationErrors.some((error) => err.message.includes(error));
+
+    if (isValidationError) {
+      return res.status(400).json({
+        success: false,
+        message: err.message,
+      });
+    }
+
+    // All other errors are server errors (500)
+    return res.status(500).json({
+      success: false,
+      message: err.message,
+    });
+  }
+});
+
+router.get('/', async (_req, res) => {
+  try {
+    const docs = await CreditNote.find();
+    res.json(docs);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.get('/:id', async (req, res) => {
+  try {
+    const doc = await CreditNote.findById(req.params.id);
+    if (!doc) return res.status(404).json({ message: 'Not found' });
+    res.json(doc);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.get('/:id/pdf', async (req, res) => {
+  try {
+    const doc = await CreditNotePDF.findOne({ nota_credito_id: req.params.id });
+    if (!doc) return res.status(404).json({ message: 'Not found' });
+    res.json(doc);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.put('/:id', async (req, res) => {
+  try {
+    const doc = await CreditNote.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!doc) return res.status(404).json({ message: 'Not found' });
+    res.json(doc);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.delete('/:id', async (req, res) => {
+  try {
+    const doc = await CreditNote.findByIdAndDelete(req.params.id);
+    if (!doc) return res.status(404).json({ message: 'Not found' });
+    res.json({ message: 'Deleted' });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+export default router;

--- a/src/routes/debitNote.ts
+++ b/src/routes/debitNote.ts
@@ -1,0 +1,110 @@
+import { Router } from 'express';
+import DebitNote from '../models/DebitNote';
+import DebitNotePDF from '../models/DebitNotePDF';
+import { DebitNoteService } from '../services/debit-note.service';
+
+const router = Router();
+
+router.post('/', async (req, res) => {
+  try {
+    const doc = new DebitNote(req.body);
+    await doc.save();
+    res.status(201).json(doc);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.post('/complete', async (req, res) => {
+  try {
+    if (!req.body.nota_debito) {
+      return res.status(400).json({
+        success: false,
+        message: 'Debit note data is required',
+      });
+    }
+
+    const resultado = await DebitNoteService.crearNotaDebitoCompleta(req.body.nota_debito);
+
+    return res.status(201).json({
+      success: true,
+      data: resultado,
+      xml: resultado.xml,
+    });
+  } catch (err: any) {
+    // Errors that should return 400 (Bad Request)
+    const validationErrors = [
+      'Client not found',
+      'Identification type not found',
+      'Empresa emisora no encontrada',
+      'Invalid date format',
+      'Datos de nota de débito inválidos o incompletos',
+    ];
+
+    const isValidationError = validationErrors.some((error) => err.message.includes(error));
+
+    if (isValidationError) {
+      return res.status(400).json({
+        success: false,
+        message: err.message,
+      });
+    }
+
+    // All other errors are server errors (500)
+    return res.status(500).json({
+      success: false,
+      message: err.message,
+    });
+  }
+});
+
+router.get('/', async (_req, res) => {
+  try {
+    const docs = await DebitNote.find();
+    res.json(docs);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.get('/:id', async (req, res) => {
+  try {
+    const doc = await DebitNote.findById(req.params.id);
+    if (!doc) return res.status(404).json({ message: 'Not found' });
+    res.json(doc);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.get('/:id/pdf', async (req, res) => {
+  try {
+    const doc = await DebitNotePDF.findOne({ nota_debito_id: req.params.id });
+    if (!doc) return res.status(404).json({ message: 'Not found' });
+    res.json(doc);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.put('/:id', async (req, res) => {
+  try {
+    const doc = await DebitNote.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!doc) return res.status(404).json({ message: 'Not found' });
+    res.json(doc);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.delete('/:id', async (req, res) => {
+  try {
+    const doc = await DebitNote.findByIdAndDelete(req.params.id);
+    if (!doc) return res.status(404).json({ message: 'Not found' });
+    res.json({ message: 'Deleted' });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+export default router;

--- a/src/routes/deliveryNote.ts
+++ b/src/routes/deliveryNote.ts
@@ -1,0 +1,108 @@
+import { Router } from 'express';
+import DeliveryNote from '../models/DeliveryNote';
+import DeliveryNotePDF from '../models/DeliveryNotePDF';
+import { DeliveryNoteService } from '../services/delivery-note.service';
+
+const router = Router();
+
+router.post('/', async (req, res) => {
+  try {
+    const doc = new DeliveryNote(req.body);
+    await doc.save();
+    res.status(201).json(doc);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.post('/complete', async (req, res) => {
+  try {
+    if (!req.body.guia_remision) {
+      return res.status(400).json({
+        success: false,
+        message: 'Delivery note data is required',
+      });
+    }
+
+    const resultado = await DeliveryNoteService.crearGuiaRemisionCompleta(req.body.guia_remision);
+
+    return res.status(201).json({
+      success: true,
+      data: resultado,
+      xml: resultado.xml,
+    });
+  } catch (err: any) {
+    // Errors that should return 400 (Bad Request)
+    const validationErrors = [
+      'Empresa emisora no encontrada',
+      'Invalid date format',
+      'Datos de guía de remisión inválidos o incompletos',
+    ];
+
+    const isValidationError = validationErrors.some((error) => err.message.includes(error));
+
+    if (isValidationError) {
+      return res.status(400).json({
+        success: false,
+        message: err.message,
+      });
+    }
+
+    // All other errors are server errors (500)
+    return res.status(500).json({
+      success: false,
+      message: err.message,
+    });
+  }
+});
+
+router.get('/', async (_req, res) => {
+  try {
+    const docs = await DeliveryNote.find();
+    res.json(docs);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.get('/:id', async (req, res) => {
+  try {
+    const doc = await DeliveryNote.findById(req.params.id);
+    if (!doc) return res.status(404).json({ message: 'Not found' });
+    res.json(doc);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.get('/:id/pdf', async (req, res) => {
+  try {
+    const doc = await DeliveryNotePDF.findOne({ guia_remision_id: req.params.id });
+    if (!doc) return res.status(404).json({ message: 'Not found' });
+    res.json(doc);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.put('/:id', async (req, res) => {
+  try {
+    const doc = await DeliveryNote.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!doc) return res.status(404).json({ message: 'Not found' });
+    res.json(doc);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.delete('/:id', async (req, res) => {
+  try {
+    const doc = await DeliveryNote.findByIdAndDelete(req.params.id);
+    if (!doc) return res.status(404).json({ message: 'Not found' });
+    res.json({ message: 'Deleted' });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+export default router;

--- a/src/routes/withholding.ts
+++ b/src/routes/withholding.ts
@@ -1,0 +1,108 @@
+import { Router } from 'express';
+import Withholding from '../models/Withholding';
+import WithholdingPDF from '../models/WithholdingPDF';
+import { WithholdingService } from '../services/withholding.service';
+
+const router = Router();
+
+router.post('/', async (req, res) => {
+  try {
+    const doc = new Withholding(req.body);
+    await doc.save();
+    res.status(201).json(doc);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.post('/complete', async (req, res) => {
+  try {
+    if (!req.body.retencion) {
+      return res.status(400).json({
+        success: false,
+        message: 'Withholding data is required',
+      });
+    }
+
+    const resultado = await WithholdingService.crearRetencionCompleta(req.body.retencion);
+
+    return res.status(201).json({
+      success: true,
+      data: resultado,
+      xml: resultado.xml,
+    });
+  } catch (err: any) {
+    // Errors that should return 400 (Bad Request)
+    const validationErrors = [
+      'Empresa emisora no encontrada',
+      'Invalid date format',
+      'Datos de comprobante de retención inválidos o incompletos',
+    ];
+
+    const isValidationError = validationErrors.some((error) => err.message.includes(error));
+
+    if (isValidationError) {
+      return res.status(400).json({
+        success: false,
+        message: err.message,
+      });
+    }
+
+    // All other errors are server errors (500)
+    return res.status(500).json({
+      success: false,
+      message: err.message,
+    });
+  }
+});
+
+router.get('/', async (_req, res) => {
+  try {
+    const docs = await Withholding.find();
+    res.json(docs);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.get('/:id', async (req, res) => {
+  try {
+    const doc = await Withholding.findById(req.params.id);
+    if (!doc) return res.status(404).json({ message: 'Not found' });
+    res.json(doc);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.get('/:id/pdf', async (req, res) => {
+  try {
+    const doc = await WithholdingPDF.findOne({ retencion_id: req.params.id });
+    if (!doc) return res.status(404).json({ message: 'Not found' });
+    res.json(doc);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.put('/:id', async (req, res) => {
+  try {
+    const doc = await Withholding.findByIdAndUpdate(req.params.id, req.body, { new: true });
+    if (!doc) return res.status(404).json({ message: 'Not found' });
+    res.json(doc);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.delete('/:id', async (req, res) => {
+  try {
+    const doc = await Withholding.findByIdAndDelete(req.params.id);
+    if (!doc) return res.status(404).json({ message: 'Not found' });
+    res.json({ message: 'Deleted' });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+export default router;

--- a/src/services/credit-note.service.ts
+++ b/src/services/credit-note.service.ts
@@ -1,0 +1,417 @@
+import { CreditNoteRequest, CreditNoteProductDetail } from '../interfaces/credit-note.interface';
+import { convertirFecha, generarClaveAcceso } from '../utils/invoice.utils';
+import { generarXMLNotaCredito } from '../utils/xml.utils';
+import { firmarXML } from '../utils/firma.utils';
+import { enviarComprobanteSRI, autorizarComprobanteSRI, AutorizacionSRI, RespuestaSRI } from '../utils/sri.utils';
+import { generateCreditNotePDF } from '../utils/pdf.utils';
+import { PDFStorageFactory } from './storage';
+import { InvoiceService } from './invoice.service';
+import CreditNote from '../models/CreditNote';
+import CreditNoteDetail from '../models/CreditNoteDetail';
+import CreditNotePDF from '../models/CreditNotePDF';
+import Invoice from '../models/Invoice';
+import IssuingCompany from '../models/IssuingCompany';
+import { IClient } from '../models/Client';
+import { IProduct } from '../models/Product';
+import fs from 'fs';
+
+/**
+ * Servicio para manejar todas las operaciones relacionadas con notas de crédito (codDoc 04)
+ */
+export class CreditNoteService {
+  /**
+   * Valida que los datos básicos de una nota de crédito estén presentes
+   */
+  static validarDatosNotaCredito(datos: CreditNoteRequest): boolean {
+    return !!(
+      datos.infoTributaria &&
+      datos.infoNotaCredito &&
+      datos.detalles &&
+      datos.detalles.length > 0 &&
+      datos.infoNotaCredito.numDocModificado &&
+      datos.infoNotaCredito.motivo
+    );
+  }
+
+  /**
+   * Genera el siguiente secuencial de nota de crédito para una empresa
+   */
+  static async generarSecuencial(rucCompany: string): Promise<string> {
+    const empresa = await IssuingCompany.findOne({ ruc: rucCompany });
+    if (!empresa) {
+      throw new Error(`Empresa with RUC ${rucCompany} not found`);
+    }
+
+    const ultimaNota = await CreditNote.findOne({
+      empresa_emisora_id: empresa._id,
+    }).sort({ secuencial: -1 });
+
+    let secuencial = '000000001';
+    if (ultimaNota) {
+      const siguiente = parseInt(ultimaNota.secuencial) + 1;
+      secuencial = siguiente.toString().padStart(9, '0');
+    }
+    return secuencial;
+  }
+
+  /**
+   * Busca todos los productos listados en los detalles de una nota de crédito
+   */
+  static async buscarProducts(detalles: CreditNoteProductDetail[]): Promise<IProduct[]> {
+    const productos = [];
+    for (const det of detalles) {
+      const codigo = det.detalle?.codigoInterno;
+      const producto = await InvoiceService.buscarProduct(codigo);
+      if (!producto) {
+        throw new Error(`Product not found: ${codigo}`);
+      }
+      productos.push(producto);
+    }
+    return productos;
+  }
+
+  /**
+   * Valida y resuelve todas las entidades necesarias para emitir la nota de crédito
+   */
+  static async procesarNotaCreditoCompleta(datos: CreditNoteRequest) {
+    if (!this.validarDatosNotaCredito(datos)) {
+      throw new Error('Datos de nota de crédito inválidos o incompletos');
+    }
+
+    const tipoIdent = await InvoiceService.buscarTipoIdentificacion(datos.infoNotaCredito.tipoIdentificacionComprador);
+    if (!tipoIdent) {
+      throw new Error('Identification type not found');
+    }
+
+    const empresa = await InvoiceService.buscarIssuingCompany(datos.infoTributaria.ruc);
+    if (!empresa) {
+      throw new Error('Empresa emisora no encontrada');
+    }
+
+    const cliente = await InvoiceService.buscarClient(datos.infoNotaCredito.identificacionComprador);
+    if (!cliente) {
+      throw new Error('Client not found');
+    }
+
+    const productos = await this.buscarProducts(datos.detalles);
+    const secuencial = await this.generarSecuencial(empresa.ruc);
+    const fechaEmision = convertirFecha(datos.infoNotaCredito.fechaEmision);
+    const fechaEmisionDocSustento = convertirFecha(datos.infoNotaCredito.fechaEmisionDocSustento);
+
+    if (isNaN(fechaEmision.getTime()) || isNaN(fechaEmisionDocSustento.getTime())) {
+      throw new Error('Invalid date format');
+    }
+
+    // Optional link to the modified invoice when it exists in this system
+    const facturaModificada = await Invoice.findOne({
+      empresa_emisora_id: empresa._id,
+      secuencial: datos.infoNotaCredito.numDocModificado.split('-').pop(),
+    });
+
+    return {
+      empresa,
+      cliente,
+      productos,
+      secuencial,
+      fechaEmision,
+      fechaEmisionDocSustento,
+      facturaModificada,
+    };
+  }
+
+  /**
+   * Procesa y guarda una nota de crédito completa con todos sus detalles,
+   * y dispara el envío asíncrono al SRI
+   * @param datos Los datos de la nota de crédito recibidos del cliente
+   * @returns La nota de crédito creada y sus detalles
+   */
+  static async crearNotaCreditoCompleta(datos: CreditNoteRequest) {
+    const { empresa, cliente, productos, secuencial, fechaEmision, fechaEmisionDocSustento, facturaModificada } =
+      await this.procesarNotaCreditoCompleta(datos);
+
+    const serie = `${empresa.codigo_establecimiento}${empresa.punto_emision}`;
+    const claveAcceso = generarClaveAcceso({
+      fecha: fechaEmision,
+      tipoComprobante: '04',
+      ruc: empresa.ruc,
+      ambiente: empresa.tipo_ambiente.toString(),
+      serie,
+      secuencial,
+      codigoNumerico: Math.floor(10000000 + Math.random() * 89999999).toString(),
+      tipoEmision: empresa.tipo_emision.toString(),
+    });
+
+    const totalSinImpuestos = parseFloat(datos.infoNotaCredito.totalSinImpuestos);
+    const totalIva = datos.detalles.reduce((s, d) => s + parseFloat(d.detalle.impuestos[0].impuesto.valor), 0);
+    const valorModificacion = parseFloat(datos.infoNotaCredito.valorModificacion);
+
+    const xml = generarXMLNotaCredito(datos, empresa, cliente, claveAcceso, secuencial);
+
+    const notaCredito = new CreditNote({
+      empresa_emisora_id: empresa._id,
+      cliente_id: cliente._id,
+      factura_modificada_id: facturaModificada?._id,
+      fecha_emision: fechaEmision,
+      clave_acceso: claveAcceso,
+      secuencial,
+      estado: 'CREADA',
+      cod_doc_modificado: datos.infoNotaCredito.codDocModificado,
+      num_doc_modificado: datos.infoNotaCredito.numDocModificado,
+      fecha_emision_doc_sustento: fechaEmisionDocSustento,
+      total_sin_impuestos: totalSinImpuestos,
+      total_iva: totalIva,
+      valor_modificacion: valorModificacion,
+      motivo: datos.infoNotaCredito.motivo,
+      xml,
+      sri_estado: 'PENDIENTE',
+      datos_originales: JSON.stringify(datos),
+    });
+
+    await notaCredito.save();
+
+    this.procesarEnvioSRI(notaCredito, empresa, cliente, productos, datos).catch((error) => {
+      console.error('Error in asynchronous SRI sending process:', error);
+    });
+
+    const detallesGuardados = await this.crearDetallesNotaCredito(notaCredito._id, datos.detalles, productos);
+
+    return {
+      nota_credito: notaCredito,
+      detalles: detallesGuardados,
+      xml: notaCredito.xml,
+      xml_firmado: notaCredito.xml_firmado || null,
+      respuesta_sri: null,
+    };
+  }
+
+  /**
+   * Crea los detalles de una nota de crédito en la base de datos
+   */
+  static async crearDetallesNotaCredito(
+    notaCreditoId: string | any,
+    detalles: CreditNoteProductDetail[],
+    products: IProduct[],
+  ) {
+    const detallesGuardados = [];
+
+    for (let i = 0; i < detalles.length; i++) {
+      const det = detalles[i].detalle;
+      const prod = products[i];
+
+      const detDoc = new CreditNoteDetail({
+        nota_credito_id: notaCreditoId,
+        producto_id: prod._id,
+        cantidad: parseFloat(det.cantidad),
+        precio_unitario: parseFloat(det.precioUnitario),
+        subtotal: parseFloat(det.precioTotalSinImpuesto),
+        valor_iva: parseFloat(det.impuestos[0].impuesto.valor),
+      });
+
+      await detDoc.save();
+      detallesGuardados.push(detDoc);
+    }
+
+    return detallesGuardados;
+  }
+
+  /**
+   * Procesa el envío asíncrono de la nota de crédito al SRI:
+   * firma XAdES-BES, recepción y consulta de autorización
+   */
+  static async procesarEnvioSRI(
+    notaCredito: any,
+    empresa: any,
+    cliente: IClient,
+    productos: IProduct[],
+    datos: CreditNoteRequest,
+  ): Promise<void> {
+    let respuestaSRI: RespuestaSRI | null = null;
+
+    try {
+      const p12Path = empresa.certificatePath;
+      const p12Password = empresa.certificatePassword || '';
+
+      if (!p12Path || !fs.existsSync(p12Path)) {
+        notaCredito.sri_estado = 'ERROR_FIRMA';
+        notaCredito.sri_mensajes = { mensaje: 'Certificate not found for signing' };
+        await notaCredito.save();
+        return;
+      }
+
+      try {
+        const diagnosis = await InvoiceService.diagnoseP12Certificate(p12Path, p12Password);
+        if (!diagnosis.isValidP12) {
+          throw new Error(`El archivo P12 no es válido: ${diagnosis.error}`);
+        }
+
+        let workingPassword = p12Password;
+        const passwordVerification = await InvoiceService.verifyP12Password(p12Path, p12Password);
+        if (!passwordVerification.valid) {
+          const passwordSearch = await InvoiceService.findWorkingP12Password(p12Path, p12Password);
+          if (passwordSearch.password === null) {
+            throw new Error(`Error de contraseña del certificado P12: ${passwordVerification.error}`);
+          }
+          workingPassword = passwordSearch.password;
+        }
+
+        const xmlFirmado = await firmarXML(notaCredito.xml, p12Path, workingPassword, '04');
+
+        notaCredito.xml_firmado = xmlFirmado;
+        notaCredito.sri_fecha_envio = new Date();
+        await notaCredito.save();
+
+        respuestaSRI = await enviarComprobanteSRI(xmlFirmado);
+
+        notaCredito.sri_fecha_respuesta = new Date();
+        notaCredito.sri_estado = respuestaSRI.estado;
+        if (respuestaSRI.mensajes) {
+          notaCredito.sri_mensajes = respuestaSRI.mensajes;
+        }
+        await notaCredito.save();
+
+        if (respuestaSRI.estado === 'RECIBIDA') {
+          console.log(
+            `✅ NOTA DE CRÉDITO RECIBIDA POR SRI - ID: ${notaCredito._id}, Clave: ${notaCredito.clave_acceso}, Secuencial: ${notaCredito.secuencial}`,
+          );
+          await this.generarPDFNotaCredito(notaCredito, empresa, cliente, productos, datos);
+          this.programarConsultaAutorizacion(String(notaCredito._id));
+        } else {
+          console.log(`⚠️ SRI Estado: ${respuestaSRI.estado} - Nota de crédito ID: ${notaCredito._id}`);
+        }
+      } catch (error: any) {
+        console.error('Error during certificate processing or signing:', error.message);
+        notaCredito.sri_estado = 'ERROR_FIRMA';
+        notaCredito.sri_mensajes = { error: error.message };
+        await notaCredito.save();
+      }
+    } catch (error: any) {
+      console.error('Error during signing or sending to SRI:', error.message);
+      notaCredito.sri_estado = 'ERROR_PROCESO';
+      notaCredito.sri_mensajes = { error: error.message };
+      await notaCredito.save();
+    }
+  }
+
+  /**
+   * Programa consultas de autorización al SRI con reintentos
+   */
+  static programarConsultaAutorizacion(notaCreditoId: string, intento = 1, maxIntentos = 3, delayMs = 5000): void {
+    const timer = setTimeout(async () => {
+      try {
+        const resultado = await CreditNoteService.consultarAutorizacionSRI(notaCreditoId);
+        const pendiente = !resultado || (resultado.estado !== 'AUTORIZADO' && resultado.estado !== 'NO AUTORIZADO');
+
+        if (pendiente && intento < maxIntentos) {
+          CreditNoteService.programarConsultaAutorizacion(notaCreditoId, intento + 1, maxIntentos, delayMs);
+        }
+      } catch (error: any) {
+        console.error('Error en la consulta de autorización automática:', error.message);
+      }
+    }, delayMs);
+
+    timer.unref?.();
+  }
+
+  /**
+   * Consulta el estado de autorización de una nota de crédito ya recibida por el SRI
+   * y actualiza el documento con el resultado
+   */
+  static async consultarAutorizacionSRI(notaCreditoId: string): Promise<AutorizacionSRI | null> {
+    try {
+      const notaCredito = await CreditNote.findById(notaCreditoId);
+      if (!notaCredito || !notaCredito.clave_acceso) {
+        throw new Error('Nota de crédito no encontrada o sin clave de acceso');
+      }
+
+      const respuesta = await autorizarComprobanteSRI(notaCredito.clave_acceso);
+
+      notaCredito.sri_estado = respuesta.estado;
+      notaCredito.sri_fecha_respuesta = new Date();
+      if (respuesta.mensajes) {
+        notaCredito.sri_mensajes = respuesta.mensajes;
+      }
+
+      if (respuesta.estado === 'AUTORIZADO') {
+        notaCredito.estado = 'AUTORIZADA';
+        notaCredito.autorizacion_numero = respuesta.numeroAutorizacion || notaCredito.clave_acceso;
+        notaCredito.fecha_autorizacion = respuesta.fechaAutorizacion
+          ? new Date(respuesta.fechaAutorizacion)
+          : new Date();
+        console.log(`✅ NOTA DE CRÉDITO AUTORIZADA POR SRI - Secuencial: ${notaCredito.secuencial}`);
+      }
+
+      await notaCredito.save();
+      return respuesta;
+    } catch (error: any) {
+      console.error('Error al consultar autorización SRI:', error.message);
+      return null;
+    }
+  }
+
+  /**
+   * Genera y almacena el PDF (RIDE) de una nota de crédito recibida por el SRI
+   */
+  static async generarPDFNotaCredito(
+    notaCredito: any,
+    empresa: any,
+    cliente: IClient,
+    productos: IProduct[],
+    datos: CreditNoteRequest,
+  ): Promise<void> {
+    try {
+      const numeroAutorizacion = notaCredito.clave_acceso;
+      const fechaAutorizacion = notaCredito.sri_fecha_respuesta || new Date();
+
+      const pdfBuffer = await generateCreditNotePDF({
+        notaCredito: datos,
+        empresa,
+        cliente,
+        productos,
+        claveAcceso: notaCredito.clave_acceso,
+        secuencial: notaCredito.secuencial,
+        fechaEmision: notaCredito.fecha_emision,
+        numeroAutorizacion,
+        fechaAutorizacion,
+      });
+
+      const storage = PDFStorageFactory.create();
+      const filename = `nota_credito_${notaCredito.secuencial}_${notaCredito.clave_acceso}`;
+      const uploadResult = await storage.upload(pdfBuffer, filename);
+
+      const creditNotePDF = new CreditNotePDF({
+        nota_credito_id: notaCredito._id,
+        claveAcceso: notaCredito.clave_acceso,
+        pdf_url: uploadResult.url,
+        pdf_public_id: uploadResult.publicId,
+        pdf_provider: uploadResult.provider,
+        tamano_archivo: uploadResult.size,
+        numero_autorizacion: numeroAutorizacion,
+        fecha_autorizacion: fechaAutorizacion,
+        estado: 'GENERADO',
+      });
+
+      await creditNotePDF.save();
+      console.log(`✅ PDF de nota de crédito guardado: ${uploadResult.url}`);
+    } catch (error) {
+      console.error('❌ Error generating credit note PDF:', error);
+
+      try {
+        const errorPDF = new CreditNotePDF({
+          nota_credito_id: notaCredito._id,
+          claveAcceso: notaCredito.clave_acceso,
+          pdf_url: '',
+          pdf_public_id: '',
+          pdf_provider: 'error',
+          tamano_archivo: 0,
+          numero_autorizacion: notaCredito.clave_acceso,
+          fecha_autorizacion: new Date(),
+          estado: 'ERROR',
+        });
+
+        await errorPDF.save();
+      } catch (dbError) {
+        console.error('❌ Error saving credit note PDF error record:', dbError);
+      }
+    }
+  }
+}

--- a/src/services/debit-note.service.ts
+++ b/src/services/debit-note.service.ts
@@ -1,0 +1,364 @@
+import { DebitNoteRequest } from '../interfaces/debit-note.interface';
+import { convertirFecha, generarClaveAcceso } from '../utils/invoice.utils';
+import { generarXMLNotaDebito } from '../utils/xml.utils';
+import { firmarXML } from '../utils/firma.utils';
+import { enviarComprobanteSRI, autorizarComprobanteSRI, AutorizacionSRI, RespuestaSRI } from '../utils/sri.utils';
+import { generateDebitNotePDF } from '../utils/pdf.utils';
+import { PDFStorageFactory } from './storage';
+import { InvoiceService } from './invoice.service';
+import DebitNote from '../models/DebitNote';
+import DebitNotePDF from '../models/DebitNotePDF';
+import Invoice from '../models/Invoice';
+import IssuingCompany from '../models/IssuingCompany';
+import { IClient } from '../models/Client';
+import fs from 'fs';
+
+/**
+ * Servicio para manejar todas las operaciones relacionadas con notas de débito (codDoc 05)
+ */
+export class DebitNoteService {
+  /**
+   * Valida que los datos básicos de una nota de débito estén presentes
+   */
+  static validarDatosNotaDebito(datos: DebitNoteRequest): boolean {
+    return !!(
+      datos.infoTributaria &&
+      datos.infoNotaDebito &&
+      datos.motivos &&
+      datos.motivos.length > 0 &&
+      datos.infoNotaDebito.numDocModificado &&
+      datos.infoNotaDebito.impuestos &&
+      datos.infoNotaDebito.impuestos.length > 0 &&
+      datos.infoNotaDebito.pagos &&
+      datos.infoNotaDebito.pagos.length > 0
+    );
+  }
+
+  /**
+   * Genera el siguiente secuencial de nota de débito para una empresa
+   */
+  static async generarSecuencial(rucCompany: string): Promise<string> {
+    const empresa = await IssuingCompany.findOne({ ruc: rucCompany });
+    if (!empresa) {
+      throw new Error(`Empresa with RUC ${rucCompany} not found`);
+    }
+
+    const ultimaNota = await DebitNote.findOne({
+      empresa_emisora_id: empresa._id,
+    }).sort({ secuencial: -1 });
+
+    let secuencial = '000000001';
+    if (ultimaNota) {
+      const siguiente = parseInt(ultimaNota.secuencial) + 1;
+      secuencial = siguiente.toString().padStart(9, '0');
+    }
+    return secuencial;
+  }
+
+  /**
+   * Valida y resuelve todas las entidades necesarias para emitir la nota de débito
+   */
+  static async procesarNotaDebitoCompleta(datos: DebitNoteRequest) {
+    if (!this.validarDatosNotaDebito(datos)) {
+      throw new Error('Datos de nota de débito inválidos o incompletos');
+    }
+
+    const tipoIdent = await InvoiceService.buscarTipoIdentificacion(datos.infoNotaDebito.tipoIdentificacionComprador);
+    if (!tipoIdent) {
+      throw new Error('Identification type not found');
+    }
+
+    const empresa = await InvoiceService.buscarIssuingCompany(datos.infoTributaria.ruc);
+    if (!empresa) {
+      throw new Error('Empresa emisora no encontrada');
+    }
+
+    const cliente = await InvoiceService.buscarClient(datos.infoNotaDebito.identificacionComprador);
+    if (!cliente) {
+      throw new Error('Client not found');
+    }
+
+    const secuencial = await this.generarSecuencial(empresa.ruc);
+    const fechaEmision = convertirFecha(datos.infoNotaDebito.fechaEmision);
+    const fechaEmisionDocSustento = convertirFecha(datos.infoNotaDebito.fechaEmisionDocSustento);
+
+    if (isNaN(fechaEmision.getTime()) || isNaN(fechaEmisionDocSustento.getTime())) {
+      throw new Error('Invalid date format');
+    }
+
+    // Optional link to the modified invoice when it exists in this system
+    const facturaModificada = await Invoice.findOne({
+      empresa_emisora_id: empresa._id,
+      secuencial: datos.infoNotaDebito.numDocModificado.split('-').pop(),
+    });
+
+    return {
+      empresa,
+      cliente,
+      secuencial,
+      fechaEmision,
+      fechaEmisionDocSustento,
+      facturaModificada,
+    };
+  }
+
+  /**
+   * Procesa y guarda una nota de débito completa,
+   * y dispara el envío asíncrono al SRI
+   * @param datos Los datos de la nota de débito recibidos del cliente
+   * @returns La nota de débito creada
+   */
+  static async crearNotaDebitoCompleta(datos: DebitNoteRequest) {
+    const { empresa, cliente, secuencial, fechaEmision, fechaEmisionDocSustento, facturaModificada } =
+      await this.procesarNotaDebitoCompleta(datos);
+
+    const serie = `${empresa.codigo_establecimiento}${empresa.punto_emision}`;
+    const claveAcceso = generarClaveAcceso({
+      fecha: fechaEmision,
+      tipoComprobante: '05',
+      ruc: empresa.ruc,
+      ambiente: empresa.tipo_ambiente.toString(),
+      serie,
+      secuencial,
+      codigoNumerico: Math.floor(10000000 + Math.random() * 89999999).toString(),
+      tipoEmision: empresa.tipo_emision.toString(),
+    });
+
+    const totalSinImpuestos = parseFloat(datos.infoNotaDebito.totalSinImpuestos);
+    const totalImpuestos = datos.infoNotaDebito.impuestos.reduce((s, i) => s + parseFloat(i.impuesto.valor), 0);
+    const valorTotal = parseFloat(datos.infoNotaDebito.valorTotal);
+
+    const xml = generarXMLNotaDebito(datos, empresa, cliente, claveAcceso, secuencial);
+
+    const notaDebito = new DebitNote({
+      empresa_emisora_id: empresa._id,
+      cliente_id: cliente._id,
+      factura_modificada_id: facturaModificada?._id,
+      fecha_emision: fechaEmision,
+      clave_acceso: claveAcceso,
+      secuencial,
+      estado: 'CREADA',
+      cod_doc_modificado: datos.infoNotaDebito.codDocModificado,
+      num_doc_modificado: datos.infoNotaDebito.numDocModificado,
+      fecha_emision_doc_sustento: fechaEmisionDocSustento,
+      total_sin_impuestos: totalSinImpuestos,
+      total_impuestos: totalImpuestos,
+      valor_total: valorTotal,
+      motivos: datos.motivos.map((m) => ({ razon: m.motivo.razon, valor: parseFloat(m.motivo.valor) })),
+      xml,
+      sri_estado: 'PENDIENTE',
+      datos_originales: JSON.stringify(datos),
+    });
+
+    await notaDebito.save();
+
+    this.procesarEnvioSRI(notaDebito, empresa, cliente, datos).catch((error) => {
+      console.error('Error in asynchronous SRI sending process:', error);
+    });
+
+    return {
+      nota_debito: notaDebito,
+      xml: notaDebito.xml,
+      xml_firmado: notaDebito.xml_firmado || null,
+      respuesta_sri: null,
+    };
+  }
+
+  /**
+   * Procesa el envío asíncrono de la nota de débito al SRI:
+   * firma XAdES-BES, recepción y consulta de autorización
+   */
+  static async procesarEnvioSRI(
+    notaDebito: any,
+    empresa: any,
+    cliente: IClient,
+    datos: DebitNoteRequest,
+  ): Promise<void> {
+    let respuestaSRI: RespuestaSRI | null = null;
+
+    try {
+      const p12Path = empresa.certificatePath;
+      const p12Password = empresa.certificatePassword || '';
+
+      if (!p12Path || !fs.existsSync(p12Path)) {
+        notaDebito.sri_estado = 'ERROR_FIRMA';
+        notaDebito.sri_mensajes = { mensaje: 'Certificate not found for signing' };
+        await notaDebito.save();
+        return;
+      }
+
+      try {
+        const diagnosis = await InvoiceService.diagnoseP12Certificate(p12Path, p12Password);
+        if (!diagnosis.isValidP12) {
+          throw new Error(`El archivo P12 no es válido: ${diagnosis.error}`);
+        }
+
+        let workingPassword = p12Password;
+        const passwordVerification = await InvoiceService.verifyP12Password(p12Path, p12Password);
+        if (!passwordVerification.valid) {
+          const passwordSearch = await InvoiceService.findWorkingP12Password(p12Path, p12Password);
+          if (passwordSearch.password === null) {
+            throw new Error(`Error de contraseña del certificado P12: ${passwordVerification.error}`);
+          }
+          workingPassword = passwordSearch.password;
+        }
+
+        const xmlFirmado = await firmarXML(notaDebito.xml, p12Path, workingPassword, '05');
+
+        notaDebito.xml_firmado = xmlFirmado;
+        notaDebito.sri_fecha_envio = new Date();
+        await notaDebito.save();
+
+        respuestaSRI = await enviarComprobanteSRI(xmlFirmado);
+
+        notaDebito.sri_fecha_respuesta = new Date();
+        notaDebito.sri_estado = respuestaSRI.estado;
+        if (respuestaSRI.mensajes) {
+          notaDebito.sri_mensajes = respuestaSRI.mensajes;
+        }
+        await notaDebito.save();
+
+        if (respuestaSRI.estado === 'RECIBIDA') {
+          console.log(
+            `✅ NOTA DE DÉBITO RECIBIDA POR SRI - ID: ${notaDebito._id}, Clave: ${notaDebito.clave_acceso}, Secuencial: ${notaDebito.secuencial}`,
+          );
+          await this.generarPDFNotaDebito(notaDebito, empresa, cliente, datos);
+          this.programarConsultaAutorizacion(String(notaDebito._id));
+        } else {
+          console.log(`⚠️ SRI Estado: ${respuestaSRI.estado} - Nota de débito ID: ${notaDebito._id}`);
+        }
+      } catch (error: any) {
+        console.error('Error during certificate processing or signing:', error.message);
+        notaDebito.sri_estado = 'ERROR_FIRMA';
+        notaDebito.sri_mensajes = { error: error.message };
+        await notaDebito.save();
+      }
+    } catch (error: any) {
+      console.error('Error during signing or sending to SRI:', error.message);
+      notaDebito.sri_estado = 'ERROR_PROCESO';
+      notaDebito.sri_mensajes = { error: error.message };
+      await notaDebito.save();
+    }
+  }
+
+  /**
+   * Programa consultas de autorización al SRI con reintentos
+   */
+  static programarConsultaAutorizacion(notaDebitoId: string, intento = 1, maxIntentos = 3, delayMs = 5000): void {
+    const timer = setTimeout(async () => {
+      try {
+        const resultado = await DebitNoteService.consultarAutorizacionSRI(notaDebitoId);
+        const pendiente = !resultado || (resultado.estado !== 'AUTORIZADO' && resultado.estado !== 'NO AUTORIZADO');
+
+        if (pendiente && intento < maxIntentos) {
+          DebitNoteService.programarConsultaAutorizacion(notaDebitoId, intento + 1, maxIntentos, delayMs);
+        }
+      } catch (error: any) {
+        console.error('Error en la consulta de autorización automática:', error.message);
+      }
+    }, delayMs);
+
+    timer.unref?.();
+  }
+
+  /**
+   * Consulta el estado de autorización de una nota de débito ya recibida por el SRI
+   * y actualiza el documento con el resultado
+   */
+  static async consultarAutorizacionSRI(notaDebitoId: string): Promise<AutorizacionSRI | null> {
+    try {
+      const notaDebito = await DebitNote.findById(notaDebitoId);
+      if (!notaDebito || !notaDebito.clave_acceso) {
+        throw new Error('Nota de débito no encontrada o sin clave de acceso');
+      }
+
+      const respuesta = await autorizarComprobanteSRI(notaDebito.clave_acceso);
+
+      notaDebito.sri_estado = respuesta.estado;
+      notaDebito.sri_fecha_respuesta = new Date();
+      if (respuesta.mensajes) {
+        notaDebito.sri_mensajes = respuesta.mensajes;
+      }
+
+      if (respuesta.estado === 'AUTORIZADO') {
+        notaDebito.estado = 'AUTORIZADA';
+        notaDebito.autorizacion_numero = respuesta.numeroAutorizacion || notaDebito.clave_acceso;
+        notaDebito.fecha_autorizacion = respuesta.fechaAutorizacion
+          ? new Date(respuesta.fechaAutorizacion)
+          : new Date();
+        console.log(`✅ NOTA DE DÉBITO AUTORIZADA POR SRI - Secuencial: ${notaDebito.secuencial}`);
+      }
+
+      await notaDebito.save();
+      return respuesta;
+    } catch (error: any) {
+      console.error('Error al consultar autorización SRI:', error.message);
+      return null;
+    }
+  }
+
+  /**
+   * Genera y almacena el PDF (RIDE) de una nota de débito recibida por el SRI
+   */
+  static async generarPDFNotaDebito(
+    notaDebito: any,
+    empresa: any,
+    cliente: IClient,
+    datos: DebitNoteRequest,
+  ): Promise<void> {
+    try {
+      const numeroAutorizacion = notaDebito.clave_acceso;
+      const fechaAutorizacion = notaDebito.sri_fecha_respuesta || new Date();
+
+      const pdfBuffer = await generateDebitNotePDF({
+        notaDebito: datos,
+        empresa,
+        cliente,
+        claveAcceso: notaDebito.clave_acceso,
+        secuencial: notaDebito.secuencial,
+        fechaEmision: notaDebito.fecha_emision,
+        numeroAutorizacion,
+        fechaAutorizacion,
+      });
+
+      const storage = PDFStorageFactory.create();
+      const filename = `nota_debito_${notaDebito.secuencial}_${notaDebito.clave_acceso}`;
+      const uploadResult = await storage.upload(pdfBuffer, filename);
+
+      const debitNotePDF = new DebitNotePDF({
+        nota_debito_id: notaDebito._id,
+        claveAcceso: notaDebito.clave_acceso,
+        pdf_url: uploadResult.url,
+        pdf_public_id: uploadResult.publicId,
+        pdf_provider: uploadResult.provider,
+        tamano_archivo: uploadResult.size,
+        numero_autorizacion: numeroAutorizacion,
+        fecha_autorizacion: fechaAutorizacion,
+        estado: 'GENERADO',
+      });
+
+      await debitNotePDF.save();
+      console.log(`✅ PDF de nota de débito guardado: ${uploadResult.url}`);
+    } catch (error) {
+      console.error('❌ Error generating debit note PDF:', error);
+
+      try {
+        const errorPDF = new DebitNotePDF({
+          nota_debito_id: notaDebito._id,
+          claveAcceso: notaDebito.clave_acceso,
+          pdf_url: '',
+          pdf_public_id: '',
+          pdf_provider: 'error',
+          tamano_archivo: 0,
+          numero_autorizacion: notaDebito.clave_acceso,
+          fecha_autorizacion: new Date(),
+          estado: 'ERROR',
+        });
+
+        await errorPDF.save();
+      } catch (dbError) {
+        console.error('❌ Error saving debit note PDF error record:', dbError);
+      }
+    }
+  }
+}

--- a/src/services/delivery-note.service.ts
+++ b/src/services/delivery-note.service.ts
@@ -1,0 +1,330 @@
+import { DeliveryNoteRequest } from '../interfaces/delivery-note.interface';
+import { convertirFecha, generarClaveAcceso } from '../utils/invoice.utils';
+import { generarXMLGuiaRemision } from '../utils/xml.utils';
+import { firmarXML } from '../utils/firma.utils';
+import { enviarComprobanteSRI, autorizarComprobanteSRI, AutorizacionSRI, RespuestaSRI } from '../utils/sri.utils';
+import { generateDeliveryNotePDF } from '../utils/pdf.utils';
+import { PDFStorageFactory } from './storage';
+import { InvoiceService } from './invoice.service';
+import DeliveryNote from '../models/DeliveryNote';
+import DeliveryNotePDF from '../models/DeliveryNotePDF';
+import IssuingCompany from '../models/IssuingCompany';
+import fs from 'fs';
+
+/**
+ * Servicio para manejar todas las operaciones relacionadas con guías de remisión (codDoc 06)
+ */
+export class DeliveryNoteService {
+  /**
+   * Valida que los datos básicos de una guía de remisión estén presentes
+   */
+  static validarDatosGuiaRemision(datos: DeliveryNoteRequest): boolean {
+    return !!(
+      datos.infoTributaria &&
+      datos.infoGuiaRemision &&
+      datos.infoGuiaRemision.dirPartida &&
+      datos.infoGuiaRemision.razonSocialTransportista &&
+      datos.infoGuiaRemision.rucTransportista &&
+      datos.infoGuiaRemision.placa &&
+      datos.destinatarios &&
+      datos.destinatarios.length > 0 &&
+      datos.destinatarios.every((d) => d.destinatario && d.destinatario.detalles && d.destinatario.detalles.length > 0)
+    );
+  }
+
+  /**
+   * Genera el siguiente secuencial de guía de remisión para una empresa
+   */
+  static async generarSecuencial(rucCompany: string): Promise<string> {
+    const empresa = await IssuingCompany.findOne({ ruc: rucCompany });
+    if (!empresa) {
+      throw new Error(`Empresa with RUC ${rucCompany} not found`);
+    }
+
+    const ultimaGuia = await DeliveryNote.findOne({
+      empresa_emisora_id: empresa._id,
+    }).sort({ secuencial: -1 });
+
+    let secuencial = '000000001';
+    if (ultimaGuia) {
+      const siguiente = parseInt(ultimaGuia.secuencial) + 1;
+      secuencial = siguiente.toString().padStart(9, '0');
+    }
+    return secuencial;
+  }
+
+  /**
+   * Valida y resuelve todas las entidades necesarias para emitir la guía de remisión
+   */
+  static async procesarGuiaRemisionCompleta(datos: DeliveryNoteRequest) {
+    if (!this.validarDatosGuiaRemision(datos)) {
+      throw new Error('Datos de guía de remisión inválidos o incompletos');
+    }
+
+    const empresa = await InvoiceService.buscarIssuingCompany(datos.infoTributaria.ruc);
+    if (!empresa) {
+      throw new Error('Empresa emisora no encontrada');
+    }
+
+    const secuencial = await this.generarSecuencial(empresa.ruc);
+    const fechaEmision = convertirFecha(datos.infoGuiaRemision.fechaEmision);
+    const fechaIniTransporte = convertirFecha(datos.infoGuiaRemision.fechaIniTransporte);
+    const fechaFinTransporte = convertirFecha(datos.infoGuiaRemision.fechaFinTransporte);
+
+    if (isNaN(fechaEmision.getTime()) || isNaN(fechaIniTransporte.getTime()) || isNaN(fechaFinTransporte.getTime())) {
+      throw new Error('Invalid date format');
+    }
+
+    return {
+      empresa,
+      secuencial,
+      fechaEmision,
+      fechaIniTransporte,
+      fechaFinTransporte,
+    };
+  }
+
+  /**
+   * Procesa y guarda una guía de remisión completa,
+   * y dispara el envío asíncrono al SRI
+   * @param datos Los datos de la guía de remisión recibidos del cliente
+   * @returns La guía de remisión creada
+   */
+  static async crearGuiaRemisionCompleta(datos: DeliveryNoteRequest) {
+    const { empresa, secuencial, fechaEmision, fechaIniTransporte, fechaFinTransporte } =
+      await this.procesarGuiaRemisionCompleta(datos);
+
+    const serie = `${empresa.codigo_establecimiento}${empresa.punto_emision}`;
+    const claveAcceso = generarClaveAcceso({
+      fecha: fechaEmision,
+      tipoComprobante: '06',
+      ruc: empresa.ruc,
+      ambiente: empresa.tipo_ambiente.toString(),
+      serie,
+      secuencial,
+      codigoNumerico: Math.floor(10000000 + Math.random() * 89999999).toString(),
+      tipoEmision: empresa.tipo_emision.toString(),
+    });
+
+    const xml = generarXMLGuiaRemision(datos, empresa, claveAcceso, secuencial);
+
+    const guiaRemision = new DeliveryNote({
+      empresa_emisora_id: empresa._id,
+      fecha_emision: fechaEmision,
+      clave_acceso: claveAcceso,
+      secuencial,
+      estado: 'CREADA',
+      dir_partida: datos.infoGuiaRemision.dirPartida,
+      razon_social_transportista: datos.infoGuiaRemision.razonSocialTransportista,
+      tipo_identificacion_transportista: datos.infoGuiaRemision.tipoIdentificacionTransportista,
+      ruc_transportista: datos.infoGuiaRemision.rucTransportista,
+      fecha_ini_transporte: fechaIniTransporte,
+      fecha_fin_transporte: fechaFinTransporte,
+      placa: datos.infoGuiaRemision.placa,
+      destinatarios: datos.destinatarios,
+      xml,
+      sri_estado: 'PENDIENTE',
+      datos_originales: JSON.stringify(datos),
+    });
+
+    await guiaRemision.save();
+
+    this.procesarEnvioSRI(guiaRemision, empresa, datos).catch((error) => {
+      console.error('Error in asynchronous SRI sending process:', error);
+    });
+
+    return {
+      guia_remision: guiaRemision,
+      xml: guiaRemision.xml,
+      xml_firmado: guiaRemision.xml_firmado || null,
+      respuesta_sri: null,
+    };
+  }
+
+  /**
+   * Procesa el envío asíncrono de la guía de remisión al SRI:
+   * firma XAdES-BES, recepción y consulta de autorización
+   */
+  static async procesarEnvioSRI(guiaRemision: any, empresa: any, datos: DeliveryNoteRequest): Promise<void> {
+    let respuestaSRI: RespuestaSRI | null = null;
+
+    try {
+      const p12Path = empresa.certificatePath;
+      const p12Password = empresa.certificatePassword || '';
+
+      if (!p12Path || !fs.existsSync(p12Path)) {
+        guiaRemision.sri_estado = 'ERROR_FIRMA';
+        guiaRemision.sri_mensajes = { mensaje: 'Certificate not found for signing' };
+        await guiaRemision.save();
+        return;
+      }
+
+      try {
+        const diagnosis = await InvoiceService.diagnoseP12Certificate(p12Path, p12Password);
+        if (!diagnosis.isValidP12) {
+          throw new Error(`El archivo P12 no es válido: ${diagnosis.error}`);
+        }
+
+        let workingPassword = p12Password;
+        const passwordVerification = await InvoiceService.verifyP12Password(p12Path, p12Password);
+        if (!passwordVerification.valid) {
+          const passwordSearch = await InvoiceService.findWorkingP12Password(p12Path, p12Password);
+          if (passwordSearch.password === null) {
+            throw new Error(`Error de contraseña del certificado P12: ${passwordVerification.error}`);
+          }
+          workingPassword = passwordSearch.password;
+        }
+
+        const xmlFirmado = await firmarXML(guiaRemision.xml, p12Path, workingPassword, '06');
+
+        guiaRemision.xml_firmado = xmlFirmado;
+        guiaRemision.sri_fecha_envio = new Date();
+        await guiaRemision.save();
+
+        respuestaSRI = await enviarComprobanteSRI(xmlFirmado);
+
+        guiaRemision.sri_fecha_respuesta = new Date();
+        guiaRemision.sri_estado = respuestaSRI.estado;
+        if (respuestaSRI.mensajes) {
+          guiaRemision.sri_mensajes = respuestaSRI.mensajes;
+        }
+        await guiaRemision.save();
+
+        if (respuestaSRI.estado === 'RECIBIDA') {
+          console.log(
+            `✅ GUÍA DE REMISIÓN RECIBIDA POR SRI - ID: ${guiaRemision._id}, Clave: ${guiaRemision.clave_acceso}, Secuencial: ${guiaRemision.secuencial}`,
+          );
+          await this.generarPDFGuiaRemision(guiaRemision, empresa, datos);
+          this.programarConsultaAutorizacion(String(guiaRemision._id));
+        } else {
+          console.log(`⚠️ SRI Estado: ${respuestaSRI.estado} - Guía de remisión ID: ${guiaRemision._id}`);
+        }
+      } catch (error: any) {
+        console.error('Error during certificate processing or signing:', error.message);
+        guiaRemision.sri_estado = 'ERROR_FIRMA';
+        guiaRemision.sri_mensajes = { error: error.message };
+        await guiaRemision.save();
+      }
+    } catch (error: any) {
+      console.error('Error during signing or sending to SRI:', error.message);
+      guiaRemision.sri_estado = 'ERROR_PROCESO';
+      guiaRemision.sri_mensajes = { error: error.message };
+      await guiaRemision.save();
+    }
+  }
+
+  /**
+   * Programa consultas de autorización al SRI con reintentos
+   */
+  static programarConsultaAutorizacion(guiaRemisionId: string, intento = 1, maxIntentos = 3, delayMs = 5000): void {
+    const timer = setTimeout(async () => {
+      try {
+        const resultado = await DeliveryNoteService.consultarAutorizacionSRI(guiaRemisionId);
+        const pendiente = !resultado || (resultado.estado !== 'AUTORIZADO' && resultado.estado !== 'NO AUTORIZADO');
+
+        if (pendiente && intento < maxIntentos) {
+          DeliveryNoteService.programarConsultaAutorizacion(guiaRemisionId, intento + 1, maxIntentos, delayMs);
+        }
+      } catch (error: any) {
+        console.error('Error en la consulta de autorización automática:', error.message);
+      }
+    }, delayMs);
+
+    timer.unref?.();
+  }
+
+  /**
+   * Consulta el estado de autorización de una guía de remisión ya recibida por el SRI
+   * y actualiza el documento con el resultado
+   */
+  static async consultarAutorizacionSRI(guiaRemisionId: string): Promise<AutorizacionSRI | null> {
+    try {
+      const guiaRemision = await DeliveryNote.findById(guiaRemisionId);
+      if (!guiaRemision || !guiaRemision.clave_acceso) {
+        throw new Error('Guía de remisión no encontrada o sin clave de acceso');
+      }
+
+      const respuesta = await autorizarComprobanteSRI(guiaRemision.clave_acceso);
+
+      guiaRemision.sri_estado = respuesta.estado;
+      guiaRemision.sri_fecha_respuesta = new Date();
+      if (respuesta.mensajes) {
+        guiaRemision.sri_mensajes = respuesta.mensajes;
+      }
+
+      if (respuesta.estado === 'AUTORIZADO') {
+        guiaRemision.estado = 'AUTORIZADA';
+        guiaRemision.autorizacion_numero = respuesta.numeroAutorizacion || guiaRemision.clave_acceso;
+        guiaRemision.fecha_autorizacion = respuesta.fechaAutorizacion
+          ? new Date(respuesta.fechaAutorizacion)
+          : new Date();
+        console.log(`✅ GUÍA DE REMISIÓN AUTORIZADA POR SRI - Secuencial: ${guiaRemision.secuencial}`);
+      }
+
+      await guiaRemision.save();
+      return respuesta;
+    } catch (error: any) {
+      console.error('Error al consultar autorización SRI:', error.message);
+      return null;
+    }
+  }
+
+  /**
+   * Genera y almacena el PDF (RIDE) de una guía de remisión recibida por el SRI
+   */
+  static async generarPDFGuiaRemision(guiaRemision: any, empresa: any, datos: DeliveryNoteRequest): Promise<void> {
+    try {
+      const numeroAutorizacion = guiaRemision.clave_acceso;
+      const fechaAutorizacion = guiaRemision.sri_fecha_respuesta || new Date();
+
+      const pdfBuffer = await generateDeliveryNotePDF({
+        guiaRemision: datos,
+        empresa,
+        claveAcceso: guiaRemision.clave_acceso,
+        secuencial: guiaRemision.secuencial,
+        fechaEmision: guiaRemision.fecha_emision,
+        numeroAutorizacion,
+        fechaAutorizacion,
+      });
+
+      const storage = PDFStorageFactory.create();
+      const filename = `guia_remision_${guiaRemision.secuencial}_${guiaRemision.clave_acceso}`;
+      const uploadResult = await storage.upload(pdfBuffer, filename);
+
+      const deliveryNotePDF = new DeliveryNotePDF({
+        guia_remision_id: guiaRemision._id,
+        claveAcceso: guiaRemision.clave_acceso,
+        pdf_url: uploadResult.url,
+        pdf_public_id: uploadResult.publicId,
+        pdf_provider: uploadResult.provider,
+        tamano_archivo: uploadResult.size,
+        numero_autorizacion: numeroAutorizacion,
+        fecha_autorizacion: fechaAutorizacion,
+        estado: 'GENERADO',
+      });
+
+      await deliveryNotePDF.save();
+      console.log(`✅ PDF de guía de remisión guardado: ${uploadResult.url}`);
+    } catch (error) {
+      console.error('❌ Error generating delivery note PDF:', error);
+
+      try {
+        const errorPDF = new DeliveryNotePDF({
+          guia_remision_id: guiaRemision._id,
+          claveAcceso: guiaRemision.clave_acceso,
+          pdf_url: '',
+          pdf_public_id: '',
+          pdf_provider: 'error',
+          tamano_archivo: 0,
+          numero_autorizacion: guiaRemision.clave_acceso,
+          fecha_autorizacion: new Date(),
+          estado: 'ERROR',
+        });
+
+        await errorPDF.save();
+      } catch (dbError) {
+        console.error('❌ Error saving delivery note PDF error record:', dbError);
+      }
+    }
+  }
+}

--- a/src/services/invoice.service.ts
+++ b/src/services/invoice.service.ts
@@ -2,7 +2,7 @@ import { CreateInvoiceDTO, InvoiceRequest, ProductDetail, AccessKeyDTO } from '.
 import { convertirFecha, generarClaveAcceso } from '../utils/invoice.utils';
 import { generarXMLFactura } from '../utils/xml.utils';
 import { firmarXML } from '../utils/firma.utils';
-import { enviarComprobanteSRI, RespuestaSRI } from '../utils/sri.utils';
+import { enviarComprobanteSRI, autorizarComprobanteSRI, RespuestaSRI, AutorizacionSRI } from '../utils/sri.utils';
 import { generateInvoicePDF } from '../utils/pdf.utils';
 import { PDFStorageFactory } from './storage';
 import Invoice from '../models/Invoice';
@@ -367,8 +367,8 @@ export class InvoiceService {
             }
           }
 
-          const pemPath = await InvoiceService.convertP12ToPem(p12Path, workingPassword);
-          const xmlFirmado = await firmarXML(factura.xml, pemPath, workingPassword);
+          // Sign directly from the P12 using the SRI-compliant XAdES-BES signer
+          const xmlFirmado = await firmarXML(factura.xml, p12Path, workingPassword, '01');
 
           factura.xml_firmado = xmlFirmado;
           await factura.save();
@@ -391,6 +391,7 @@ export class InvoiceService {
                 `✅ FACTURA RECIBIDA POR SRI - ID: ${factura._id}, Clave: ${factura.clave_acceso}, Secuencial: ${factura.secuencial}`,
               );
               await this.generarPDFFactura(factura, empresa, cliente, productos, datosFactura);
+              this.programarConsultaAutorizacion(String(factura._id));
             } else {
               console.log(`⚠️ SRI Estado: ${respuestaSRI.estado} - Factura ID: ${factura._id}`);
             }
@@ -622,6 +623,69 @@ export class InvoiceService {
       } catch (dbError) {
         console.error('❌ Error saving PDF error record:', dbError);
       }
+    }
+  }
+
+  /**
+   * Programa consultas de autorización al SRI con reintentos.
+   * En el esquema offline la autorización es asíncrona: tras la recepción,
+   * el comprobante puede tardar unos segundos en ser autorizado.
+   * @param facturaId ID de la factura a consultar
+   * @param intento Número de intento actual
+   * @param maxIntentos Número máximo de intentos
+   * @param delayMs Espera entre intentos en milisegundos
+   */
+  static programarConsultaAutorizacion(facturaId: string, intento = 1, maxIntentos = 3, delayMs = 5000): void {
+    const timer = setTimeout(async () => {
+      try {
+        const resultado = await InvoiceService.consultarAutorizacionSRI(facturaId);
+        const pendiente = !resultado || (resultado.estado !== 'AUTORIZADO' && resultado.estado !== 'NO AUTORIZADO');
+
+        if (pendiente && intento < maxIntentos) {
+          InvoiceService.programarConsultaAutorizacion(facturaId, intento + 1, maxIntentos, delayMs);
+        }
+      } catch (error: any) {
+        console.error('Error en la consulta de autorización automática:', error.message);
+      }
+    }, delayMs);
+
+    // Do not keep the process alive because of the scheduled check
+    timer.unref?.();
+  }
+
+  /**
+   * Consulta el estado de autorización de una factura ya recibida por el SRI
+   * y actualiza el documento con el resultado.
+   * En el esquema offline el número de autorización es la propia clave de acceso.
+   * @param facturaId ID de la factura a consultar
+   */
+  static async consultarAutorizacionSRI(facturaId: string): Promise<AutorizacionSRI | null> {
+    try {
+      const factura = await Invoice.findById(facturaId);
+      if (!factura || !factura.clave_acceso) {
+        throw new Error('Factura no encontrada o sin clave de acceso');
+      }
+
+      const respuesta = await autorizarComprobanteSRI(factura.clave_acceso);
+
+      factura.sri_estado = respuesta.estado;
+      factura.sri_fecha_respuesta = new Date();
+      if (respuesta.mensajes) {
+        factura.sri_mensajes = respuesta.mensajes;
+      }
+
+      if (respuesta.estado === 'AUTORIZADO') {
+        factura.estado = 'AUTORIZADA';
+        factura.autorizacion_numero = respuesta.numeroAutorizacion || factura.clave_acceso;
+        factura.fecha_autorizacion = respuesta.fechaAutorizacion ? new Date(respuesta.fechaAutorizacion) : new Date();
+        console.log(`✅ FACTURA AUTORIZADA POR SRI - Secuencial: ${factura.secuencial}`);
+      }
+
+      await factura.save();
+      return respuesta;
+    } catch (error: any) {
+      console.error('Error al consultar autorización SRI:', error.message);
+      return null;
     }
   }
 

--- a/src/services/withholding.service.ts
+++ b/src/services/withholding.service.ts
@@ -1,0 +1,334 @@
+import { WithholdingRequest } from '../interfaces/withholding.interface';
+import { convertirFecha, generarClaveAcceso } from '../utils/invoice.utils';
+import { generarXMLRetencion } from '../utils/xml.utils';
+import { firmarXML } from '../utils/firma.utils';
+import { enviarComprobanteSRI, autorizarComprobanteSRI, AutorizacionSRI, RespuestaSRI } from '../utils/sri.utils';
+import { generateWithholdingPDF } from '../utils/pdf.utils';
+import { PDFStorageFactory } from './storage';
+import { InvoiceService } from './invoice.service';
+import Withholding from '../models/Withholding';
+import WithholdingPDF from '../models/WithholdingPDF';
+import IssuingCompany from '../models/IssuingCompany';
+import fs from 'fs';
+
+/**
+ * Servicio para manejar todas las operaciones relacionadas con
+ * comprobantes de retención ATS 2.0.0 (codDoc 07)
+ */
+export class WithholdingService {
+  /**
+   * Valida que los datos básicos de un comprobante de retención estén presentes
+   */
+  static validarDatosRetencion(datos: WithholdingRequest): boolean {
+    return !!(
+      datos.infoTributaria &&
+      datos.infoCompRetencion &&
+      datos.infoCompRetencion.identificacionSujetoRetenido &&
+      datos.infoCompRetencion.razonSocialSujetoRetenido &&
+      datos.infoCompRetencion.periodoFiscal &&
+      datos.docsSustento &&
+      datos.docsSustento.length > 0 &&
+      datos.docsSustento.every(
+        (d) =>
+          d.docSustento &&
+          d.docSustento.retenciones &&
+          d.docSustento.retenciones.length > 0 &&
+          d.docSustento.impuestosDocSustento &&
+          d.docSustento.impuestosDocSustento.length > 0 &&
+          d.docSustento.pagos &&
+          d.docSustento.pagos.length > 0,
+      )
+    );
+  }
+
+  /**
+   * Genera el siguiente secuencial de comprobante de retención para una empresa
+   */
+  static async generarSecuencial(rucCompany: string): Promise<string> {
+    const empresa = await IssuingCompany.findOne({ ruc: rucCompany });
+    if (!empresa) {
+      throw new Error(`Empresa with RUC ${rucCompany} not found`);
+    }
+
+    const ultimaRetencion = await Withholding.findOne({
+      empresa_emisora_id: empresa._id,
+    }).sort({ secuencial: -1 });
+
+    let secuencial = '000000001';
+    if (ultimaRetencion) {
+      const siguiente = parseInt(ultimaRetencion.secuencial) + 1;
+      secuencial = siguiente.toString().padStart(9, '0');
+    }
+    return secuencial;
+  }
+
+  /**
+   * Valida y resuelve todas las entidades necesarias para emitir el comprobante
+   */
+  static async procesarRetencionCompleta(datos: WithholdingRequest) {
+    if (!this.validarDatosRetencion(datos)) {
+      throw new Error('Datos de comprobante de retención inválidos o incompletos');
+    }
+
+    const empresa = await InvoiceService.buscarIssuingCompany(datos.infoTributaria.ruc);
+    if (!empresa) {
+      throw new Error('Empresa emisora no encontrada');
+    }
+
+    const secuencial = await this.generarSecuencial(empresa.ruc);
+    const fechaEmision = convertirFecha(datos.infoCompRetencion.fechaEmision);
+
+    if (isNaN(fechaEmision.getTime())) {
+      throw new Error('Invalid date format');
+    }
+
+    return {
+      empresa,
+      secuencial,
+      fechaEmision,
+    };
+  }
+
+  /**
+   * Procesa y guarda un comprobante de retención completo,
+   * y dispara el envío asíncrono al SRI
+   * @param datos Los datos del comprobante de retención recibidos del cliente
+   * @returns El comprobante de retención creado
+   */
+  static async crearRetencionCompleta(datos: WithholdingRequest) {
+    const { empresa, secuencial, fechaEmision } = await this.procesarRetencionCompleta(datos);
+
+    const serie = `${empresa.codigo_establecimiento}${empresa.punto_emision}`;
+    const claveAcceso = generarClaveAcceso({
+      fecha: fechaEmision,
+      tipoComprobante: '07',
+      ruc: empresa.ruc,
+      ambiente: empresa.tipo_ambiente.toString(),
+      serie,
+      secuencial,
+      codigoNumerico: Math.floor(10000000 + Math.random() * 89999999).toString(),
+      tipoEmision: empresa.tipo_emision.toString(),
+    });
+
+    const totalRetenido = datos.docsSustento
+      .flatMap((d) => d.docSustento.retenciones)
+      .reduce((s, r) => s + parseFloat(r.retencion.valorRetenido), 0);
+
+    const xml = generarXMLRetencion(datos, empresa, claveAcceso, secuencial);
+
+    const retencion = new Withholding({
+      empresa_emisora_id: empresa._id,
+      fecha_emision: fechaEmision,
+      clave_acceso: claveAcceso,
+      secuencial,
+      estado: 'CREADA',
+      tipo_identificacion_sujeto_retenido: datos.infoCompRetencion.tipoIdentificacionSujetoRetenido,
+      razon_social_sujeto_retenido: datos.infoCompRetencion.razonSocialSujetoRetenido,
+      identificacion_sujeto_retenido: datos.infoCompRetencion.identificacionSujetoRetenido,
+      periodo_fiscal: datos.infoCompRetencion.periodoFiscal,
+      total_retenido: totalRetenido,
+      docs_sustento: datos.docsSustento,
+      xml,
+      sri_estado: 'PENDIENTE',
+      datos_originales: JSON.stringify(datos),
+    });
+
+    await retencion.save();
+
+    this.procesarEnvioSRI(retencion, empresa, datos).catch((error) => {
+      console.error('Error in asynchronous SRI sending process:', error);
+    });
+
+    return {
+      retencion,
+      xml: retencion.xml,
+      xml_firmado: retencion.xml_firmado || null,
+      respuesta_sri: null,
+    };
+  }
+
+  /**
+   * Procesa el envío asíncrono del comprobante de retención al SRI:
+   * firma XAdES-BES, recepción y consulta de autorización
+   */
+  static async procesarEnvioSRI(retencion: any, empresa: any, datos: WithholdingRequest): Promise<void> {
+    let respuestaSRI: RespuestaSRI | null = null;
+
+    try {
+      const p12Path = empresa.certificatePath;
+      const p12Password = empresa.certificatePassword || '';
+
+      if (!p12Path || !fs.existsSync(p12Path)) {
+        retencion.sri_estado = 'ERROR_FIRMA';
+        retencion.sri_mensajes = { mensaje: 'Certificate not found for signing' };
+        await retencion.save();
+        return;
+      }
+
+      try {
+        const diagnosis = await InvoiceService.diagnoseP12Certificate(p12Path, p12Password);
+        if (!diagnosis.isValidP12) {
+          throw new Error(`El archivo P12 no es válido: ${diagnosis.error}`);
+        }
+
+        let workingPassword = p12Password;
+        const passwordVerification = await InvoiceService.verifyP12Password(p12Path, p12Password);
+        if (!passwordVerification.valid) {
+          const passwordSearch = await InvoiceService.findWorkingP12Password(p12Path, p12Password);
+          if (passwordSearch.password === null) {
+            throw new Error(`Error de contraseña del certificado P12: ${passwordVerification.error}`);
+          }
+          workingPassword = passwordSearch.password;
+        }
+
+        const xmlFirmado = await firmarXML(retencion.xml, p12Path, workingPassword, '07');
+
+        retencion.xml_firmado = xmlFirmado;
+        retencion.sri_fecha_envio = new Date();
+        await retencion.save();
+
+        respuestaSRI = await enviarComprobanteSRI(xmlFirmado);
+
+        retencion.sri_fecha_respuesta = new Date();
+        retencion.sri_estado = respuestaSRI.estado;
+        if (respuestaSRI.mensajes) {
+          retencion.sri_mensajes = respuestaSRI.mensajes;
+        }
+        await retencion.save();
+
+        if (respuestaSRI.estado === 'RECIBIDA') {
+          console.log(
+            `✅ RETENCIÓN RECIBIDA POR SRI - ID: ${retencion._id}, Clave: ${retencion.clave_acceso}, Secuencial: ${retencion.secuencial}`,
+          );
+          await this.generarPDFRetencion(retencion, empresa, datos);
+          this.programarConsultaAutorizacion(String(retencion._id));
+        } else {
+          console.log(`⚠️ SRI Estado: ${respuestaSRI.estado} - Retención ID: ${retencion._id}`);
+        }
+      } catch (error: any) {
+        console.error('Error during certificate processing or signing:', error.message);
+        retencion.sri_estado = 'ERROR_FIRMA';
+        retencion.sri_mensajes = { error: error.message };
+        await retencion.save();
+      }
+    } catch (error: any) {
+      console.error('Error during signing or sending to SRI:', error.message);
+      retencion.sri_estado = 'ERROR_PROCESO';
+      retencion.sri_mensajes = { error: error.message };
+      await retencion.save();
+    }
+  }
+
+  /**
+   * Programa consultas de autorización al SRI con reintentos
+   */
+  static programarConsultaAutorizacion(retencionId: string, intento = 1, maxIntentos = 3, delayMs = 5000): void {
+    const timer = setTimeout(async () => {
+      try {
+        const resultado = await WithholdingService.consultarAutorizacionSRI(retencionId);
+        const pendiente = !resultado || (resultado.estado !== 'AUTORIZADO' && resultado.estado !== 'NO AUTORIZADO');
+
+        if (pendiente && intento < maxIntentos) {
+          WithholdingService.programarConsultaAutorizacion(retencionId, intento + 1, maxIntentos, delayMs);
+        }
+      } catch (error: any) {
+        console.error('Error en la consulta de autorización automática:', error.message);
+      }
+    }, delayMs);
+
+    timer.unref?.();
+  }
+
+  /**
+   * Consulta el estado de autorización de un comprobante de retención ya recibido
+   * por el SRI y actualiza el documento con el resultado
+   */
+  static async consultarAutorizacionSRI(retencionId: string): Promise<AutorizacionSRI | null> {
+    try {
+      const retencion = await Withholding.findById(retencionId);
+      if (!retencion || !retencion.clave_acceso) {
+        throw new Error('Comprobante de retención no encontrado o sin clave de acceso');
+      }
+
+      const respuesta = await autorizarComprobanteSRI(retencion.clave_acceso);
+
+      retencion.sri_estado = respuesta.estado;
+      retencion.sri_fecha_respuesta = new Date();
+      if (respuesta.mensajes) {
+        retencion.sri_mensajes = respuesta.mensajes;
+      }
+
+      if (respuesta.estado === 'AUTORIZADO') {
+        retencion.estado = 'AUTORIZADA';
+        retencion.autorizacion_numero = respuesta.numeroAutorizacion || retencion.clave_acceso;
+        retencion.fecha_autorizacion = respuesta.fechaAutorizacion ? new Date(respuesta.fechaAutorizacion) : new Date();
+        console.log(`✅ RETENCIÓN AUTORIZADA POR SRI - Secuencial: ${retencion.secuencial}`);
+      }
+
+      await retencion.save();
+      return respuesta;
+    } catch (error: any) {
+      console.error('Error al consultar autorización SRI:', error.message);
+      return null;
+    }
+  }
+
+  /**
+   * Genera y almacena el PDF (RIDE) de un comprobante de retención recibido por el SRI
+   */
+  static async generarPDFRetencion(retencion: any, empresa: any, datos: WithholdingRequest): Promise<void> {
+    try {
+      const numeroAutorizacion = retencion.clave_acceso;
+      const fechaAutorizacion = retencion.sri_fecha_respuesta || new Date();
+
+      const pdfBuffer = await generateWithholdingPDF({
+        retencion: datos,
+        empresa,
+        claveAcceso: retencion.clave_acceso,
+        secuencial: retencion.secuencial,
+        fechaEmision: retencion.fecha_emision,
+        numeroAutorizacion,
+        fechaAutorizacion,
+      });
+
+      const storage = PDFStorageFactory.create();
+      const filename = `retencion_${retencion.secuencial}_${retencion.clave_acceso}`;
+      const uploadResult = await storage.upload(pdfBuffer, filename);
+
+      const withholdingPDF = new WithholdingPDF({
+        retencion_id: retencion._id,
+        claveAcceso: retencion.clave_acceso,
+        pdf_url: uploadResult.url,
+        pdf_public_id: uploadResult.publicId,
+        pdf_provider: uploadResult.provider,
+        tamano_archivo: uploadResult.size,
+        numero_autorizacion: numeroAutorizacion,
+        fecha_autorizacion: fechaAutorizacion,
+        estado: 'GENERADO',
+      });
+
+      await withholdingPDF.save();
+      console.log(`✅ PDF de retención guardado: ${uploadResult.url}`);
+    } catch (error) {
+      console.error('❌ Error generating withholding PDF:', error);
+
+      try {
+        const errorPDF = new WithholdingPDF({
+          retencion_id: retencion._id,
+          claveAcceso: retencion.clave_acceso,
+          pdf_url: '',
+          pdf_public_id: '',
+          pdf_provider: 'error',
+          tamano_archivo: 0,
+          numero_autorizacion: retencion.clave_acceso,
+          fecha_autorizacion: new Date(),
+          estado: 'ERROR',
+        });
+
+        await errorPDF.save();
+      } catch (dbError) {
+        console.error('❌ Error saving withholding PDF error record:', dbError);
+      }
+    }
+  }
+}

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -418,6 +418,70 @@ export default {
         responses: { '200': { description: 'OK' }, '404': { description: 'Not found' } },
       },
     },
+    '/api/v1/debit-note': {
+      get: { tags: ['Debit Note CRUD'], summary: 'List Debit Notes', responses: { '200': { description: 'OK' } } },
+      post: {
+        tags: ['Debit Note CRUD'],
+        summary: 'Create Nota de Débito',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': { schema: { $ref: '#/components/schemas/NotaDebito' } },
+          },
+        },
+        responses: { '201': { description: 'Created' } },
+      },
+    },
+    '/api/v1/debit-note/complete': {
+      post: {
+        tags: ['Debit Note Processing'],
+        summary: 'Create Nota de Débito completa (XML, firma, envío y autorización SRI)',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': { schema: { $ref: '#/components/schemas/NotaDebitoComplete' } },
+          },
+        },
+        responses: {
+          '201': { description: 'Created' },
+          '400': { description: 'Validation error' },
+        },
+      },
+    },
+    '/api/v1/debit-note/{id}': {
+      get: {
+        tags: ['Debit Note CRUD'],
+        summary: 'Get Nota de Débito',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        responses: { '200': { description: 'OK' }, '404': { description: 'Not found' } },
+      },
+      put: {
+        tags: ['Debit Note CRUD'],
+        summary: 'Update Nota de Débito',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': { schema: { $ref: '#/components/schemas/NotaDebito' } },
+          },
+        },
+        responses: { '200': { description: 'Updated' }, '404': { description: 'Not found' } },
+      },
+      delete: {
+        tags: ['Debit Note CRUD'],
+        summary: 'Delete Nota de Débito',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        responses: { '200': { description: 'Deleted' }, '404': { description: 'Not found' } },
+      },
+    },
+    '/api/v1/debit-note/{id}/pdf': {
+      get: {
+        tags: ['Debit Note Processing'],
+        summary: 'Get Nota de Débito PDF (RIDE) info',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        responses: { '200': { description: 'OK' }, '404': { description: 'Not found' } },
+      },
+    },
     '/api/v1/invoice-detail': {
       get: {
         tags: ['Invoice Detail Management'],
@@ -876,6 +940,91 @@ export default {
         required: ['codigo', 'codigoPorcentaje', 'tarifa', 'baseImponible', 'valor'],
       },
       NotaCredito: { type: 'object' },
+      NotaDebito: { type: 'object' },
+      NotaDebitoComplete: {
+        type: 'object',
+        properties: {
+          nota_debito: { $ref: '#/components/schemas/NotaDebitoBody' },
+        },
+        required: ['nota_debito'],
+      },
+      NotaDebitoBody: {
+        type: 'object',
+        properties: {
+          infoTributaria: { $ref: '#/components/schemas/FacturaInfoTributaria' },
+          infoNotaDebito: { $ref: '#/components/schemas/NotaDebitoInfo' },
+          motivos: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/NotaDebitoMotivoItem' },
+          },
+        },
+        required: ['infoTributaria', 'infoNotaDebito', 'motivos'],
+      },
+      NotaDebitoInfo: {
+        type: 'object',
+        properties: {
+          fechaEmision: { type: 'string', example: '17/05/2025', description: 'Formato DD/MM/YYYY' },
+          tipoIdentificacionComprador: { type: 'string', example: '05' },
+          identificacionComprador: { type: 'string', example: '0106079783' },
+          razonSocialComprador: { type: 'string', example: 'Juan Pérez' },
+          codDocModificado: { type: 'string', example: '01', description: 'Tabla 3 SRI. 01 = Factura' },
+          numDocModificado: { type: 'string', example: '001-001-000000123' },
+          fechaEmisionDocSustento: { type: 'string', example: '10/05/2025', description: 'Formato DD/MM/YYYY' },
+          totalSinImpuestos: { type: 'string', example: '50.00' },
+          impuestos: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/FacturaDetalleImpuesto' },
+            description: 'La tarifa de IVA corresponde a la fecha de emisión del documento de sustento',
+          },
+          valorTotal: { type: 'string', example: '57.50' },
+          pagos: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/NotaDebitoPagoItem' },
+          },
+        },
+        required: [
+          'fechaEmision',
+          'tipoIdentificacionComprador',
+          'identificacionComprador',
+          'codDocModificado',
+          'numDocModificado',
+          'fechaEmisionDocSustento',
+          'totalSinImpuestos',
+          'impuestos',
+          'valorTotal',
+          'pagos',
+        ],
+      },
+      NotaDebitoPagoItem: {
+        type: 'object',
+        properties: {
+          pago: {
+            type: 'object',
+            properties: {
+              formaPago: { type: 'string', example: '20', description: 'Tabla 24 SRI' },
+              total: { type: 'string', example: '57.50' },
+              plazo: { type: 'string', example: '15' },
+              unidadTiempo: { type: 'string', example: 'dias' },
+            },
+            required: ['formaPago', 'total'],
+          },
+        },
+        required: ['pago'],
+      },
+      NotaDebitoMotivoItem: {
+        type: 'object',
+        properties: {
+          motivo: {
+            type: 'object',
+            properties: {
+              razon: { type: 'string', example: 'Interés por mora' },
+              valor: { type: 'string', example: '50.00' },
+            },
+            required: ['razon', 'valor'],
+          },
+        },
+        required: ['motivo'],
+      },
       NotaCreditoComplete: {
         type: 'object',
         properties: {

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -354,6 +354,70 @@ export default {
         responses: { '200': { description: 'Deleted' } },
       },
     },
+    '/api/v1/credit-note': {
+      get: { tags: ['Credit Note CRUD'], summary: 'List Credit Notes', responses: { '200': { description: 'OK' } } },
+      post: {
+        tags: ['Credit Note CRUD'],
+        summary: 'Create Nota de Crédito',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': { schema: { $ref: '#/components/schemas/NotaCredito' } },
+          },
+        },
+        responses: { '201': { description: 'Created' } },
+      },
+    },
+    '/api/v1/credit-note/complete': {
+      post: {
+        tags: ['Credit Note Processing'],
+        summary: 'Create Nota de Crédito with details (XML, firma, envío y autorización SRI)',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': { schema: { $ref: '#/components/schemas/NotaCreditoComplete' } },
+          },
+        },
+        responses: {
+          '201': { description: 'Created' },
+          '400': { description: 'Validation error' },
+        },
+      },
+    },
+    '/api/v1/credit-note/{id}': {
+      get: {
+        tags: ['Credit Note CRUD'],
+        summary: 'Get Nota de Crédito',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        responses: { '200': { description: 'OK' }, '404': { description: 'Not found' } },
+      },
+      put: {
+        tags: ['Credit Note CRUD'],
+        summary: 'Update Nota de Crédito',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': { schema: { $ref: '#/components/schemas/NotaCredito' } },
+          },
+        },
+        responses: { '200': { description: 'Updated' }, '404': { description: 'Not found' } },
+      },
+      delete: {
+        tags: ['Credit Note CRUD'],
+        summary: 'Delete Nota de Crédito',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        responses: { '200': { description: 'Deleted' }, '404': { description: 'Not found' } },
+      },
+    },
+    '/api/v1/credit-note/{id}/pdf': {
+      get: {
+        tags: ['Credit Note Processing'],
+        summary: 'Get Nota de Crédito PDF (RIDE) info',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        responses: { '200': { description: 'OK' }, '404': { description: 'Not found' } },
+      },
+    },
     '/api/v1/invoice-detail': {
       get: {
         tags: ['Invoice Detail Management'],
@@ -804,12 +868,83 @@ export default {
         type: 'object',
         properties: {
           codigo: { type: 'string', example: '2' },
-          codigoPorcentaje: { type: 'string', example: '2' },
-          tarifa: { type: 'string', example: '12.00' },
+          codigoPorcentaje: { type: 'string', example: '4', description: 'Tabla 17 SRI. 4 = IVA 15%' },
+          tarifa: { type: 'string', example: '15.00' },
           baseImponible: { type: 'string', example: '100.00' },
-          valor: { type: 'string', example: '12.00' },
+          valor: { type: 'string', example: '15.00' },
         },
         required: ['codigo', 'codigoPorcentaje', 'tarifa', 'baseImponible', 'valor'],
+      },
+      NotaCredito: { type: 'object' },
+      NotaCreditoComplete: {
+        type: 'object',
+        properties: {
+          nota_credito: { $ref: '#/components/schemas/NotaCreditoBody' },
+        },
+        required: ['nota_credito'],
+      },
+      NotaCreditoBody: {
+        type: 'object',
+        properties: {
+          infoTributaria: { $ref: '#/components/schemas/FacturaInfoTributaria' },
+          infoNotaCredito: { $ref: '#/components/schemas/NotaCreditoInfo' },
+          detalles: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/NotaCreditoDetalleItem' },
+          },
+        },
+        required: ['infoTributaria', 'infoNotaCredito', 'detalles'],
+      },
+      NotaCreditoInfo: {
+        type: 'object',
+        properties: {
+          fechaEmision: { type: 'string', example: '17/05/2025', description: 'Formato DD/MM/YYYY' },
+          tipoIdentificacionComprador: { type: 'string', example: '05' },
+          identificacionComprador: { type: 'string', example: '0106079783' },
+          razonSocialComprador: { type: 'string', example: 'Juan Pérez' },
+          codDocModificado: { type: 'string', example: '01', description: 'Tabla 3 SRI. 01 = Factura' },
+          numDocModificado: { type: 'string', example: '001-001-000000123' },
+          fechaEmisionDocSustento: { type: 'string', example: '10/05/2025', description: 'Formato DD/MM/YYYY' },
+          totalSinImpuestos: { type: 'string', example: '100.00' },
+          valorModificacion: { type: 'string', example: '115.00' },
+          moneda: { type: 'string', example: 'DOLAR' },
+          motivo: { type: 'string', example: 'DEVOLUCIÓN' },
+        },
+        required: [
+          'fechaEmision',
+          'tipoIdentificacionComprador',
+          'identificacionComprador',
+          'codDocModificado',
+          'numDocModificado',
+          'fechaEmisionDocSustento',
+          'totalSinImpuestos',
+          'valorModificacion',
+          'motivo',
+        ],
+      },
+      NotaCreditoDetalleItem: {
+        type: 'object',
+        properties: {
+          detalle: { $ref: '#/components/schemas/NotaCreditoDetalleData' },
+        },
+        required: ['detalle'],
+      },
+      NotaCreditoDetalleData: {
+        type: 'object',
+        properties: {
+          codigoInterno: { type: 'string', example: 'P001' },
+          codigoAdicional: { type: 'string', example: 'A001' },
+          descripcion: { type: 'string', example: 'Laptop Lenovo' },
+          cantidad: { type: 'string', example: '1.00' },
+          precioUnitario: { type: 'string', example: '100.00' },
+          descuento: { type: 'string', example: '0.00' },
+          precioTotalSinImpuesto: { type: 'string', example: '100.00' },
+          impuestos: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/FacturaDetalleImpuesto' },
+          },
+        },
+        required: ['codigoInterno', 'descripcion', 'cantidad', 'precioUnitario', 'precioTotalSinImpuesto', 'impuestos'],
       },
       UserRegistration: {
         type: 'object',

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -483,7 +483,11 @@ export default {
       },
     },
     '/api/v1/delivery-note': {
-      get: { tags: ['Delivery Note CRUD'], summary: 'List Delivery Notes', responses: { '200': { description: 'OK' } } },
+      get: {
+        tags: ['Delivery Note CRUD'],
+        summary: 'List Delivery Notes',
+        responses: { '200': { description: 'OK' } },
+      },
       post: {
         tags: ['Delivery Note CRUD'],
         summary: 'Create Guía de Remisión',
@@ -661,20 +665,6 @@ export default {
         description:
           'Obtiene una lista de todos los PDFs de facturas que han sido generados automáticamente cuando el SRI confirma la recepción (estado RECIBIDA).',
         security: [{ bearerAuth: [] }],
-        parameters: [
-          {
-            name: 'page',
-            in: 'query',
-            schema: { type: 'integer', default: 1 },
-            description: 'Número de página',
-          },
-          {
-            name: 'limit',
-            in: 'query',
-            schema: { type: 'integer', default: 10 },
-            description: 'Elementos por página',
-          },
-        ],
         responses: {
           '200': {
             description: 'Lista de PDFs obtenida exitosamente',
@@ -707,15 +697,15 @@ export default {
         },
       },
     },
-    '/api/v1/invoice-pdf/factura/{id}': {
+    '/api/v1/invoice-pdf/invoice/{facturaId}': {
       get: {
         tags: ['PDF Management'],
         summary: 'Obtener PDF por ID de factura',
-        description: 'Busca el PDF generado automáticamente para una factura específica usando su ID.',
+        description: 'Busca el registro del PDF generado automáticamente para una factura específica usando su ID.',
         security: [{ bearerAuth: [] }],
         parameters: [
           {
-            name: 'id',
+            name: 'facturaId',
             in: 'path',
             required: true,
             schema: { type: 'string' },
@@ -727,15 +717,7 @@ export default {
           '200': {
             description: 'PDF encontrado',
             content: {
-              'application/json': {
-                schema: {
-                  type: 'object',
-                  properties: {
-                    success: { type: 'boolean', example: true },
-                    data: { $ref: '#/components/schemas/InvoicePDF' },
-                  },
-                },
-              },
+              'application/json': { schema: { $ref: '#/components/schemas/InvoicePDF' } },
             },
           },
           '404': { description: 'PDF no encontrado - La factura aún no ha sido confirmada por el SRI o no existe' },
@@ -744,52 +726,11 @@ export default {
         },
       },
     },
-    '/api/v1/invoice-pdf/{id}/download': {
-      get: {
-        tags: ['PDF Management'],
-        summary: 'Descargar archivo PDF',
-        description:
-          'Descarga el archivo PDF de una factura. El PDF se genera automáticamente cuando el SRI confirma la recepción.',
-        security: [{ bearerAuth: [] }],
-        parameters: [
-          {
-            name: 'id',
-            in: 'path',
-            required: true,
-            schema: { type: 'string' },
-            description: 'ID del documento PDF',
-            example: '64f8a1b2c3d4e5f6a7b8c9d8',
-          },
-        ],
-        responses: {
-          '200': {
-            description: 'Archivo PDF descargado',
-            content: {
-              'application/pdf': {
-                schema: {
-                  type: 'string',
-                  format: 'binary',
-                },
-              },
-            },
-            headers: {
-              'Content-Disposition': {
-                description: 'Attachment filename',
-                schema: { type: 'string', example: 'attachment; filename="factura-001-001-000000001.pdf"' },
-              },
-            },
-          },
-          '404': { description: 'PDF no encontrado o archivo no existe en el sistema' },
-          '401': { description: 'No autorizado' },
-          '500': { description: 'Error del servidor' },
-        },
-      },
-    },
-    '/api/v1/invoice-pdf/clave/{claveAcceso}': {
+    '/api/v1/invoice-pdf/access-key/{claveAcceso}': {
       get: {
         tags: ['PDF Management'],
         summary: 'Obtener PDF por clave de acceso',
-        description: 'Busca el PDF usando la clave de acceso de 49 dígitos de la factura electrónica.',
+        description: 'Busca el registro del PDF usando la clave de acceso de 49 dígitos de la factura electrónica.',
         security: [{ bearerAuth: [] }],
         parameters: [
           {
@@ -805,70 +746,78 @@ export default {
           '200': {
             description: 'PDF encontrado',
             content: {
-              'application/json': {
-                schema: {
-                  type: 'object',
-                  properties: {
-                    success: { type: 'boolean', example: true },
-                    data: { $ref: '#/components/schemas/InvoicePDF' },
-                  },
-                },
-              },
+              'application/json': { schema: { $ref: '#/components/schemas/InvoicePDF' } },
             },
           },
-          '400': { description: 'Clave de acceso inválida (debe tener 49 dígitos)' },
           '404': { description: 'PDF no encontrado para esta clave de acceso' },
           '401': { description: 'No autorizado' },
           '500': { description: 'Error del servidor' },
         },
       },
     },
-    '/api/v1/invoice-pdf/regenerate/{id}': {
-      post: {
+    '/api/v1/invoice-pdf/download/{claveAcceso}': {
+      get: {
         tags: ['PDF Management'],
-        summary: 'Regenerar PDF de factura',
+        summary: 'Descargar el PDF (redirección a la URL pública)',
         description:
-          'Regenera el PDF de una factura que ya fue confirmada por el SRI. Útil si el archivo se perdió o se necesita actualizar el formato.',
+          'Redirige (302) a la URL pública del PDF en el proveedor de almacenamiento configurado (Cloudinary, local, etc.).',
         security: [{ bearerAuth: [] }],
         parameters: [
           {
-            name: 'id',
+            name: 'claveAcceso',
+            in: 'path',
+            required: true,
+            schema: { type: 'string', minLength: 49, maxLength: 49 },
+            description: 'Clave de acceso de 49 dígitos de la factura',
+          },
+        ],
+        responses: {
+          '302': { description: 'Redirección a la URL pública del PDF' },
+          '404': { description: 'PDF no encontrado o sin URL disponible' },
+          '401': { description: 'No autorizado' },
+          '500': { description: 'Error del servidor' },
+        },
+      },
+    },
+    '/api/v1/invoice-pdf/regenerate/{facturaId}': {
+      post: {
+        tags: ['PDF Management'],
+        summary: 'Solicitar regeneración del PDF de una factura',
+        description:
+          'Registra una solicitud de regeneración del PDF. Actualmente responde con un acuse de recibo; la regeneración automática está planificada.',
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          {
+            name: 'facturaId',
             in: 'path',
             required: true,
             schema: { type: 'string' },
             description: 'ID de la factura',
-            example: '64f8a1b2c3d4e5f6a7b8c9d2',
           },
         ],
         responses: {
-          '200': {
-            description: 'PDF regenerado exitosamente',
-            content: {
-              'application/json': {
-                schema: {
-                  type: 'object',
-                  properties: {
-                    success: { type: 'boolean', example: true },
-                    message: { type: 'string', example: 'PDF regenerado exitosamente' },
-                    data: { $ref: '#/components/schemas/InvoicePDF' },
-                  },
-                },
-              },
-            },
-          },
-          '400': { description: 'La factura no ha sido confirmada por el SRI (estado debe ser RECIBIDA)' },
-          '404': { description: 'Factura no encontrada' },
+          '200': { description: 'Solicitud de regeneración registrada' },
           '401': { description: 'No autorizado' },
-          '500': { description: 'Error del servidor al regenerar PDF' },
+          '500': { description: 'Error del servidor' },
         },
       },
     },
-    '/api/v1/invoice-pdf/bulk-download': {
+    '/api/v1/invoice-pdf/send-email/{claveAcceso}': {
       post: {
         tags: ['PDF Management'],
-        summary: 'Descarga masiva de PDFs',
-        description: 'Descarga múltiples PDFs de facturas en un archivo ZIP.',
+        summary: 'Solicitar el envío del PDF por email',
+        description:
+          'Marca el PDF para envío por email al destinatario indicado (estado PENDIENTE). El envío se procesa de forma asíncrona.',
         security: [{ bearerAuth: [] }],
+        parameters: [
+          {
+            name: 'claveAcceso',
+            in: 'path',
+            required: true,
+            schema: { type: 'string', minLength: 49, maxLength: 49 },
+            description: 'Clave de acceso de 49 dígitos de la factura',
+          },
+        ],
         requestBody: {
           required: true,
           content: {
@@ -876,51 +825,82 @@ export default {
               schema: {
                 type: 'object',
                 properties: {
-                  facturaIds: {
-                    type: 'array',
-                    items: { type: 'string' },
-                    description: 'Array de IDs de facturas',
-                    example: ['64f8a1b2c3d4e5f6a7b8c9d2', '64f8a1b2c3d4e5f6a7b8c9d3'],
-                  },
-                  fechaInicio: {
-                    type: 'string',
-                    format: 'date',
-                    description: 'Fecha de inicio (formato YYYY-MM-DD)',
-                    example: '2025-01-01',
-                  },
-                  fechaFin: {
-                    type: 'string',
-                    format: 'date',
-                    description: 'Fecha de fin (formato YYYY-MM-DD)',
-                    example: '2025-01-31',
-                  },
+                  email_destinatario: { type: 'string', example: 'cliente@correo.com' },
                 },
+                required: ['email_destinatario'],
               },
             },
           },
         },
         responses: {
+          '200': { description: 'Solicitud de envío encolada (estado PENDIENTE)' },
+          '400': { description: 'email_destinatario es requerido' },
+          '404': { description: 'PDF no encontrado' },
+          '401': { description: 'No autorizado' },
+          '500': { description: 'Error del servidor' },
+        },
+      },
+    },
+    '/api/v1/invoice-pdf/email-status/{claveAcceso}': {
+      get: {
+        tags: ['PDF Management'],
+        summary: 'Consultar el estado de envío por email de un PDF',
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          {
+            name: 'claveAcceso',
+            in: 'path',
+            required: true,
+            schema: { type: 'string', minLength: 49, maxLength: 49 },
+            description: 'Clave de acceso de 49 dígitos de la factura',
+          },
+        ],
+        responses: {
           '200': {
-            description: 'Archivo ZIP con PDFs descargado',
+            description: 'Estado de envío del email',
             content: {
-              'application/zip': {
+              'application/json': {
                 schema: {
-                  type: 'string',
-                  format: 'binary',
+                  type: 'object',
+                  properties: {
+                    claveAcceso: { type: 'string' },
+                    email_estado: { type: 'string', example: 'PENDIENTE' },
+                    email_destinatario: { type: 'string' },
+                    email_fecha_envio: { type: 'string', format: 'date-time' },
+                    email_intentos: { type: 'integer' },
+                    email_ultimo_error: { type: 'string' },
+                  },
                 },
               },
             },
-            headers: {
-              'Content-Disposition': {
-                description: 'Attachment filename',
-                schema: { type: 'string', example: 'attachment; filename="facturas-2025-01.zip"' },
-              },
-            },
           },
-          '400': { description: 'Parámetros de búsqueda inválidos' },
+          '404': { description: 'PDF no encontrado' },
           '401': { description: 'No autorizado' },
-          '404': { description: 'No se encontraron PDFs para los criterios especificados' },
-          '500': { description: 'Error del servidor al generar ZIP' },
+          '500': { description: 'Error del servidor' },
+        },
+      },
+    },
+    '/api/v1/invoice-pdf/retry-email/{claveAcceso}': {
+      post: {
+        tags: ['PDF Management'],
+        summary: 'Reintentar el envío por email de un PDF',
+        description: 'Reinicia el estado de envío a PENDIENTE para un PDF cuyo email falló o no se ha enviado.',
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          {
+            name: 'claveAcceso',
+            in: 'path',
+            required: true,
+            schema: { type: 'string', minLength: 49, maxLength: 49 },
+            description: 'Clave de acceso de 49 dígitos de la factura',
+          },
+        ],
+        responses: {
+          '200': { description: 'Reintento de envío registrado (estado PENDIENTE)' },
+          '400': { description: 'El email ya fue enviado exitosamente' },
+          '404': { description: 'PDF no encontrado' },
+          '401': { description: 'No autorizado' },
+          '500': { description: 'Error del servidor' },
         },
       },
     },

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -482,6 +482,70 @@ export default {
         responses: { '200': { description: 'OK' }, '404': { description: 'Not found' } },
       },
     },
+    '/api/v1/delivery-note': {
+      get: { tags: ['Delivery Note CRUD'], summary: 'List Delivery Notes', responses: { '200': { description: 'OK' } } },
+      post: {
+        tags: ['Delivery Note CRUD'],
+        summary: 'Create Guía de Remisión',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': { schema: { $ref: '#/components/schemas/GuiaRemision' } },
+          },
+        },
+        responses: { '201': { description: 'Created' } },
+      },
+    },
+    '/api/v1/delivery-note/complete': {
+      post: {
+        tags: ['Delivery Note Processing'],
+        summary: 'Create Guía de Remisión completa (XML, firma, envío y autorización SRI)',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': { schema: { $ref: '#/components/schemas/GuiaRemisionComplete' } },
+          },
+        },
+        responses: {
+          '201': { description: 'Created' },
+          '400': { description: 'Validation error' },
+        },
+      },
+    },
+    '/api/v1/delivery-note/{id}': {
+      get: {
+        tags: ['Delivery Note CRUD'],
+        summary: 'Get Guía de Remisión',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        responses: { '200': { description: 'OK' }, '404': { description: 'Not found' } },
+      },
+      put: {
+        tags: ['Delivery Note CRUD'],
+        summary: 'Update Guía de Remisión',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': { schema: { $ref: '#/components/schemas/GuiaRemision' } },
+          },
+        },
+        responses: { '200': { description: 'Updated' }, '404': { description: 'Not found' } },
+      },
+      delete: {
+        tags: ['Delivery Note CRUD'],
+        summary: 'Delete Guía de Remisión',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        responses: { '200': { description: 'Deleted' }, '404': { description: 'Not found' } },
+      },
+    },
+    '/api/v1/delivery-note/{id}/pdf': {
+      get: {
+        tags: ['Delivery Note Processing'],
+        summary: 'Get Guía de Remisión PDF (RIDE) info',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        responses: { '200': { description: 'OK' }, '404': { description: 'Not found' } },
+      },
+    },
     '/api/v1/invoice-detail': {
       get: {
         tags: ['Invoice Detail Management'],
@@ -941,6 +1005,100 @@ export default {
       },
       NotaCredito: { type: 'object' },
       NotaDebito: { type: 'object' },
+      GuiaRemision: { type: 'object' },
+      GuiaRemisionComplete: {
+        type: 'object',
+        properties: {
+          guia_remision: { $ref: '#/components/schemas/GuiaRemisionBody' },
+        },
+        required: ['guia_remision'],
+      },
+      GuiaRemisionBody: {
+        type: 'object',
+        properties: {
+          infoTributaria: { $ref: '#/components/schemas/FacturaInfoTributaria' },
+          infoGuiaRemision: { $ref: '#/components/schemas/GuiaRemisionInfo' },
+          destinatarios: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/GuiaRemisionDestinatarioItem' },
+          },
+        },
+        required: ['infoTributaria', 'infoGuiaRemision', 'destinatarios'],
+      },
+      GuiaRemisionInfo: {
+        type: 'object',
+        properties: {
+          fechaEmision: {
+            type: 'string',
+            example: '17/05/2025',
+            description: 'Formato DD/MM/YYYY. Se usa para la clave de acceso',
+          },
+          dirPartida: { type: 'string', example: 'Av. Eloy Alfaro 34 y Av. Libertad' },
+          razonSocialTransportista: { type: 'string', example: 'Transportes S.A.' },
+          tipoIdentificacionTransportista: { type: 'string', example: '04', description: 'Tabla 6 SRI' },
+          rucTransportista: { type: 'string', example: '1796875790001' },
+          fechaIniTransporte: { type: 'string', example: '17/05/2025', description: 'Formato DD/MM/YYYY' },
+          fechaFinTransporte: { type: 'string', example: '18/05/2025', description: 'Formato DD/MM/YYYY' },
+          placa: { type: 'string', example: 'MCL0827' },
+        },
+        required: [
+          'fechaEmision',
+          'dirPartida',
+          'razonSocialTransportista',
+          'tipoIdentificacionTransportista',
+          'rucTransportista',
+          'fechaIniTransporte',
+          'fechaFinTransporte',
+          'placa',
+        ],
+      },
+      GuiaRemisionDestinatarioItem: {
+        type: 'object',
+        properties: {
+          destinatario: {
+            type: 'object',
+            properties: {
+              identificacionDestinatario: { type: 'string', example: '1716849140001' },
+              razonSocialDestinatario: { type: 'string', example: 'Juan Pérez' },
+              dirDestinatario: { type: 'string', example: 'Av. Simón Bolívar S/N' },
+              motivoTraslado: { type: 'string', example: 'Venta de mercadería' },
+              ruta: { type: 'string', example: 'Quito - Cayambe - Otavalo' },
+              codDocSustento: { type: 'string', example: '01', description: 'Tabla 3 SRI' },
+              numDocSustento: { type: 'string', example: '001-001-000000123' },
+              numAutDocSustento: { type: 'string', example: '1705202501179001234500110010010000000011234567810' },
+              fechaEmisionDocSustento: { type: 'string', example: '17/05/2025' },
+              detalles: {
+                type: 'array',
+                items: { $ref: '#/components/schemas/GuiaRemisionDetalleItem' },
+              },
+            },
+            required: [
+              'identificacionDestinatario',
+              'razonSocialDestinatario',
+              'dirDestinatario',
+              'motivoTraslado',
+              'detalles',
+            ],
+          },
+        },
+        required: ['destinatario'],
+      },
+      GuiaRemisionDetalleItem: {
+        type: 'object',
+        properties: {
+          detalle: {
+            type: 'object',
+            properties: {
+              codigoInterno: { type: 'string', example: 'P001' },
+              codigoAdicional: { type: 'string', example: 'A001' },
+              descripcion: { type: 'string', example: 'Laptop Lenovo' },
+              cantidad: { type: 'string', example: '10.00', description: 'Sin precios: solo cantidades' },
+            },
+            required: ['descripcion', 'cantidad'],
+          },
+        },
+        required: ['detalle'],
+      },
       NotaDebitoComplete: {
         type: 'object',
         properties: {

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -546,6 +546,70 @@ export default {
         responses: { '200': { description: 'OK' }, '404': { description: 'Not found' } },
       },
     },
+    '/api/v1/withholding': {
+      get: { tags: ['Withholding CRUD'], summary: 'List Withholdings', responses: { '200': { description: 'OK' } } },
+      post: {
+        tags: ['Withholding CRUD'],
+        summary: 'Create Comprobante de Retención',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': { schema: { $ref: '#/components/schemas/Retencion' } },
+          },
+        },
+        responses: { '201': { description: 'Created' } },
+      },
+    },
+    '/api/v1/withholding/complete': {
+      post: {
+        tags: ['Withholding Processing'],
+        summary: 'Create Comprobante de Retención ATS 2.0.0 completo (XML, firma, envío y autorización SRI)',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': { schema: { $ref: '#/components/schemas/RetencionComplete' } },
+          },
+        },
+        responses: {
+          '201': { description: 'Created' },
+          '400': { description: 'Validation error' },
+        },
+      },
+    },
+    '/api/v1/withholding/{id}': {
+      get: {
+        tags: ['Withholding CRUD'],
+        summary: 'Get Comprobante de Retención',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        responses: { '200': { description: 'OK' }, '404': { description: 'Not found' } },
+      },
+      put: {
+        tags: ['Withholding CRUD'],
+        summary: 'Update Comprobante de Retención',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': { schema: { $ref: '#/components/schemas/Retencion' } },
+          },
+        },
+        responses: { '200': { description: 'Updated' }, '404': { description: 'Not found' } },
+      },
+      delete: {
+        tags: ['Withholding CRUD'],
+        summary: 'Delete Comprobante de Retención',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        responses: { '200': { description: 'Deleted' }, '404': { description: 'Not found' } },
+      },
+    },
+    '/api/v1/withholding/{id}/pdf': {
+      get: {
+        tags: ['Withholding Processing'],
+        summary: 'Get Comprobante de Retención PDF (RIDE) info',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        responses: { '200': { description: 'OK' }, '404': { description: 'Not found' } },
+      },
+    },
     '/api/v1/invoice-detail': {
       get: {
         tags: ['Invoice Detail Management'],
@@ -1006,6 +1070,140 @@ export default {
       NotaCredito: { type: 'object' },
       NotaDebito: { type: 'object' },
       GuiaRemision: { type: 'object' },
+      Retencion: { type: 'object' },
+      RetencionComplete: {
+        type: 'object',
+        properties: {
+          retencion: { $ref: '#/components/schemas/RetencionBody' },
+        },
+        required: ['retencion'],
+      },
+      RetencionBody: {
+        type: 'object',
+        properties: {
+          infoTributaria: { $ref: '#/components/schemas/FacturaInfoTributaria' },
+          infoCompRetencion: { $ref: '#/components/schemas/RetencionInfo' },
+          docsSustento: {
+            type: 'array',
+            items: { $ref: '#/components/schemas/RetencionDocSustentoItem' },
+          },
+        },
+        required: ['infoTributaria', 'infoCompRetencion', 'docsSustento'],
+      },
+      RetencionInfo: {
+        type: 'object',
+        properties: {
+          fechaEmision: { type: 'string', example: '17/05/2025', description: 'Formato DD/MM/YYYY' },
+          tipoIdentificacionSujetoRetenido: { type: 'string', example: '04', description: 'Tabla 6 SRI' },
+          tipoSujetoRetenido: {
+            type: 'string',
+            example: '01',
+            description: 'Tabla 14 Catálogo ATS. Obligatorio si la identificación es del exterior',
+          },
+          parteRel: { type: 'string', example: 'NO', description: 'Parte relacionada SI/NO' },
+          razonSocialSujetoRetenido: { type: 'string', example: 'Proveedor S.A.' },
+          identificacionSujetoRetenido: { type: 'string', example: '1713328506001' },
+          periodoFiscal: { type: 'string', example: '05/2025', description: 'Formato MM/YYYY' },
+        },
+        required: [
+          'fechaEmision',
+          'tipoIdentificacionSujetoRetenido',
+          'razonSocialSujetoRetenido',
+          'identificacionSujetoRetenido',
+          'periodoFiscal',
+        ],
+      },
+      RetencionDocSustentoItem: {
+        type: 'object',
+        properties: {
+          docSustento: {
+            type: 'object',
+            properties: {
+              codSustento: { type: 'string', example: '01', description: 'Tabla 5 Catálogo ATS' },
+              codDocSustento: { type: 'string', example: '01', description: 'Tabla 4 Catálogo ATS' },
+              numDocSustento: { type: 'string', example: '001001000000123', description: '15 dígitos' },
+              fechaEmisionDocSustento: { type: 'string', example: '10/05/2025' },
+              fechaRegistroContable: { type: 'string', example: '10/05/2025' },
+              numAutDocSustento: { type: 'string', example: '1005202501179001234500110010010000001231234567818' },
+              pagoLocExt: { type: 'string', example: '01', description: 'Tabla 15 Catálogo ATS. 01 = pago local' },
+              totalSinImpuestos: { type: 'string', example: '100.00' },
+              importeTotal: { type: 'string', example: '115.00' },
+              impuestosDocSustento: {
+                type: 'array',
+                items: { $ref: '#/components/schemas/RetencionImpuestoDocSustentoItem' },
+              },
+              retenciones: {
+                type: 'array',
+                items: { $ref: '#/components/schemas/RetencionDetalleItem' },
+              },
+              pagos: {
+                type: 'array',
+                items: { $ref: '#/components/schemas/RetencionPagoItem' },
+              },
+            },
+            required: [
+              'codSustento',
+              'codDocSustento',
+              'fechaEmisionDocSustento',
+              'pagoLocExt',
+              'totalSinImpuestos',
+              'importeTotal',
+              'impuestosDocSustento',
+              'retenciones',
+              'pagos',
+            ],
+          },
+        },
+        required: ['docSustento'],
+      },
+      RetencionImpuestoDocSustentoItem: {
+        type: 'object',
+        properties: {
+          impuestoDocSustento: {
+            type: 'object',
+            properties: {
+              codImpuestoDocSustento: { type: 'string', example: '2', description: 'Tabla 16 SRI. 2 = IVA' },
+              codigoPorcentaje: { type: 'string', example: '4', description: 'Tabla 17/18 SRI' },
+              baseImponible: { type: 'string', example: '100.00' },
+              tarifa: { type: 'string', example: '15' },
+              valorImpuesto: { type: 'string', example: '15.00' },
+            },
+            required: ['codImpuestoDocSustento', 'codigoPorcentaje', 'baseImponible', 'tarifa', 'valorImpuesto'],
+          },
+        },
+        required: ['impuestoDocSustento'],
+      },
+      RetencionDetalleItem: {
+        type: 'object',
+        properties: {
+          retencion: {
+            type: 'object',
+            properties: {
+              codigo: { type: 'string', example: '1', description: 'Tabla 19 SRI. 1=Renta, 2=IVA, 6=ISD' },
+              codigoRetencion: { type: 'string', example: '312', description: 'Tablas 20/21 SRI' },
+              baseImponible: { type: 'string', example: '100.00' },
+              porcentajeRetener: { type: 'string', example: '1.75' },
+              valorRetenido: { type: 'string', example: '1.75' },
+            },
+            required: ['codigo', 'codigoRetencion', 'baseImponible', 'porcentajeRetener', 'valorRetenido'],
+          },
+        },
+        required: ['retencion'],
+      },
+      RetencionPagoItem: {
+        type: 'object',
+        properties: {
+          pago: {
+            type: 'object',
+            properties: {
+              formaPago: { type: 'string', example: '01', description: 'Tabla 13 Catálogo ATS' },
+              total: { type: 'string', example: '115.00' },
+            },
+            required: ['formaPago', 'total'],
+          },
+        },
+        required: ['pago'],
+      },
       GuiaRemisionComplete: {
         type: 'object',
         properties: {

--- a/src/testApp.ts
+++ b/src/testApp.ts
@@ -6,6 +6,7 @@ import clientRoutes from './routes/client';
 import productRoutes from './routes/product';
 import invoiceRoutes from './routes/invoice';
 import creditNoteRoutes from './routes/creditNote';
+import debitNoteRoutes from './routes/debitNote';
 import invoiceDetailRoutes from './routes/invoiceDetail';
 import verifyToken from './middleware/verifyToken';
 
@@ -20,6 +21,7 @@ export function createApp() {
   app.use('/api/v1/product', productRoutes);
   app.use('/api/v1/invoice', invoiceRoutes);
   app.use('/api/v1/credit-note', creditNoteRoutes);
+  app.use('/api/v1/debit-note', debitNoteRoutes);
   app.use('/api/v1/invoice-detail', invoiceDetailRoutes);
   return app;
 }

--- a/src/testApp.ts
+++ b/src/testApp.ts
@@ -7,6 +7,7 @@ import productRoutes from './routes/product';
 import invoiceRoutes from './routes/invoice';
 import creditNoteRoutes from './routes/creditNote';
 import debitNoteRoutes from './routes/debitNote';
+import deliveryNoteRoutes from './routes/deliveryNote';
 import invoiceDetailRoutes from './routes/invoiceDetail';
 import verifyToken from './middleware/verifyToken';
 
@@ -22,6 +23,7 @@ export function createApp() {
   app.use('/api/v1/invoice', invoiceRoutes);
   app.use('/api/v1/credit-note', creditNoteRoutes);
   app.use('/api/v1/debit-note', debitNoteRoutes);
+  app.use('/api/v1/delivery-note', deliveryNoteRoutes);
   app.use('/api/v1/invoice-detail', invoiceDetailRoutes);
   return app;
 }

--- a/src/testApp.ts
+++ b/src/testApp.ts
@@ -10,6 +10,7 @@ import debitNoteRoutes from './routes/debitNote';
 import deliveryNoteRoutes from './routes/deliveryNote';
 import withholdingRoutes from './routes/withholding';
 import invoiceDetailRoutes from './routes/invoiceDetail';
+import invoicePDFRoutes from './routes/invoicePDF';
 import verifyToken from './middleware/verifyToken';
 
 export function createApp() {
@@ -27,5 +28,6 @@ export function createApp() {
   app.use('/api/v1/delivery-note', deliveryNoteRoutes);
   app.use('/api/v1/withholding', withholdingRoutes);
   app.use('/api/v1/invoice-detail', invoiceDetailRoutes);
+  app.use('/api/v1/invoice-pdf', invoicePDFRoutes);
   return app;
 }

--- a/src/testApp.ts
+++ b/src/testApp.ts
@@ -5,6 +5,7 @@ import issuingCompanyRoutes from './routes/issuingCompany';
 import clientRoutes from './routes/client';
 import productRoutes from './routes/product';
 import invoiceRoutes from './routes/invoice';
+import creditNoteRoutes from './routes/creditNote';
 import invoiceDetailRoutes from './routes/invoiceDetail';
 import verifyToken from './middleware/verifyToken';
 
@@ -18,6 +19,7 @@ export function createApp() {
   app.use('/api/v1/client', clientRoutes);
   app.use('/api/v1/product', productRoutes);
   app.use('/api/v1/invoice', invoiceRoutes);
+  app.use('/api/v1/credit-note', creditNoteRoutes);
   app.use('/api/v1/invoice-detail', invoiceDetailRoutes);
   return app;
 }

--- a/src/testApp.ts
+++ b/src/testApp.ts
@@ -8,6 +8,7 @@ import invoiceRoutes from './routes/invoice';
 import creditNoteRoutes from './routes/creditNote';
 import debitNoteRoutes from './routes/debitNote';
 import deliveryNoteRoutes from './routes/deliveryNote';
+import withholdingRoutes from './routes/withholding';
 import invoiceDetailRoutes from './routes/invoiceDetail';
 import verifyToken from './middleware/verifyToken';
 
@@ -24,6 +25,7 @@ export function createApp() {
   app.use('/api/v1/credit-note', creditNoteRoutes);
   app.use('/api/v1/debit-note', debitNoteRoutes);
   app.use('/api/v1/delivery-note', deliveryNoteRoutes);
+  app.use('/api/v1/withholding', withholdingRoutes);
   app.use('/api/v1/invoice-detail', invoiceDetailRoutes);
   return app;
 }

--- a/src/utils/encryption.utils.ts
+++ b/src/utils/encryption.utils.ts
@@ -1,7 +1,20 @@
 import crypto from 'crypto';
 
 const algorithm = 'aes-256-cbc';
-const key = (process.env.ENCRYPTION_KEY || '').padEnd(32, '0').slice(0, 32);
+
+const loadEncryptionKey = (): Buffer => {
+  const rawKey = process.env.ENCRYPTION_KEY;
+  if (!rawKey) {
+    throw new Error('ENCRYPTION_KEY environment variable is not set');
+  }
+  const key = Buffer.from(rawKey, 'hex');
+  if (key.length !== 32) {
+    throw new Error(`ENCRYPTION_KEY must decode to 32 bytes (64 hex characters), got ${key.length} bytes`);
+  }
+  return key;
+};
+
+const key = loadEncryptionKey();
 
 export function encrypt(text: string): string {
   const iv = crypto.randomBytes(16);

--- a/src/utils/firma.utils.ts
+++ b/src/utils/firma.utils.ts
@@ -63,12 +63,16 @@ function extraerCertificadoFirmante(
 
   const keyLocalKeyId = keyBag.attributes?.localKeyId?.[0];
 
-  // Preferred: certificate whose localKeyId matches the private key's localKeyId
+  // Preferred: certificate whose localKeyId matches the private key's localKeyId.
+  // A CA certificate can never be the signer, so matches are discarded if they are CA.
   let certificado: forge.pki.Certificate | undefined;
   if (keyLocalKeyId) {
-    certificado = certBags.find((bag) => bag.cert && bag.attributes?.localKeyId?.[0] === keyLocalKeyId)?.cert as
+    const coincidencia = certBags.find((bag) => bag.cert && bag.attributes?.localKeyId?.[0] === keyLocalKeyId)?.cert as
       | forge.pki.Certificate
       | undefined;
+    if (coincidencia && !esCertificadoCA(coincidencia)) {
+      certificado = coincidencia;
+    }
   }
 
   // Fallback: first non-CA certificate

--- a/src/utils/firma.utils.ts
+++ b/src/utils/firma.utils.ts
@@ -1,89 +1,129 @@
 import fs from 'fs';
-import { DOMParser } from '@xmldom/xmldom';
-import { SignedXml } from 'xml-crypto';
 import forge from 'node-forge';
+import {
+  signInvoiceXml,
+  signCreditNoteXml,
+  signDebitNoteXml,
+  signDeliveryGuideXml,
+  signWithholdingCertificateXml,
+} from 'ec-sri-invoice-signer';
 
-interface KeyInfoProvider {
-  getKeyInfo(): string;
+/**
+ * Códigos de tipo de documento según la tabla 3 de la Ficha Técnica del SRI
+ */
+export type TipoDocumento = '01' | '04' | '05' | '06' | '07';
+
+type SignerFn = (xml: string, p12Data: Buffer, options?: { pkcs12Password?: string }) => string;
+
+const FIRMADORES: Record<TipoDocumento, SignerFn> = {
+  '01': signInvoiceXml,
+  '04': signCreditNoteXml,
+  '05': signDebitNoteXml,
+  '06': signDeliveryGuideXml,
+  '07': signWithholdingCertificateXml,
+};
+
+/**
+ * Determines whether a certificate is a CA certificate (part of the chain, not the signer)
+ */
+function esCertificadoCA(cert: forge.pki.Certificate): boolean {
+  const basicConstraints = cert.getExtension('basicConstraints') as { cA?: boolean } | null;
+  if (basicConstraints && typeof basicConstraints.cA === 'boolean') {
+    return basicConstraints.cA;
+  }
+  // Fallback heuristic for certificates without basicConstraints
+  const cn = cert.subject.getField({ shortName: 'CN' })?.value || '';
+  return cn.includes('AUTORIDAD') || cn.startsWith('AC ');
 }
 
 /**
- * Firma un documento XML usando un certificado PEM
- * @param xmlString String del XML a firmar
- * @param pemPath Ruta al archivo PEM del certificado
- * @param password Contraseña del certificado (opcional para PEM)
+ * Extracts the signing certificate and its private key from a P12 file.
+ * Ecuadorian P12 files (BCE, Security Data, etc.) usually bundle the CA chain,
+ * so the signer certificate is selected by matching the private key's localKeyId,
+ * with a fallback to the first non-CA certificate.
+ */
+function extraerCertificadoFirmante(
+  p12Buffer: Buffer,
+  password: string,
+): { certificado: forge.pki.Certificate; clavePrivada: forge.pki.PrivateKey } {
+  const p12Der = forge.util.decode64(p12Buffer.toString('base64'));
+  const p12Asn1 = forge.asn1.fromDer(p12Der);
+  const p12 = forge.pkcs12.pkcs12FromAsn1(p12Asn1, true, password);
+
+  const certBags = p12.getBags({ bagType: forge.pki.oids.certBag })[forge.pki.oids.certBag] || [];
+  const keyBags = [
+    ...(p12.getBags({ bagType: forge.pki.oids.pkcs8ShroudedKeyBag })[forge.pki.oids.pkcs8ShroudedKeyBag] || []),
+    ...(p12.getBags({ bagType: forge.pki.oids.keyBag })[forge.pki.oids.keyBag] || []),
+  ];
+
+  const keyBag = keyBags[0];
+  if (!keyBag || !keyBag.key) {
+    throw new Error('No se encontró una clave privada en el archivo P12');
+  }
+
+  const keyLocalKeyId = keyBag.attributes?.localKeyId?.[0];
+
+  // Preferred: certificate whose localKeyId matches the private key's localKeyId
+  let certificado: forge.pki.Certificate | undefined;
+  if (keyLocalKeyId) {
+    certificado = certBags.find((bag) => bag.cert && bag.attributes?.localKeyId?.[0] === keyLocalKeyId)?.cert as
+      | forge.pki.Certificate
+      | undefined;
+  }
+
+  // Fallback: first non-CA certificate
+  if (!certificado) {
+    certificado = certBags.find((bag) => bag.cert && !esCertificadoCA(bag.cert))?.cert as
+      | forge.pki.Certificate
+      | undefined;
+  }
+
+  // Last resort: first certificate available
+  if (!certificado) {
+    certificado = certBags[0]?.cert as forge.pki.Certificate | undefined;
+  }
+
+  if (!certificado) {
+    throw new Error('No se encontró el certificado de firma digital en el archivo P12');
+  }
+
+  return { certificado, clavePrivada: keyBag.key };
+}
+
+/**
+ * Firma un documento XML según el estándar XAdES-BES exigido por el SRI,
+ * usando la librería ec-sri-invoice-signer.
+ *
+ * Se reconstruye un P12 mínimo (certificado firmante + clave privada) para evitar
+ * ambigüedad cuando el archivo original incluye la cadena de certificados de la CA.
+ *
+ * @param xmlString String del XML a firmar (nodo raíz con id="comprobante")
+ * @param p12Path Ruta al archivo P12 del certificado digital
+ * @param password Contraseña del certificado P12
+ * @param tipoDocumento Código del tipo de documento (tabla 3 del SRI). Por defecto '01' (factura)
  * @returns String del XML firmado
  */
-export async function firmarXML(xmlString: string, pemPath: string, password: string): Promise<string> {
+export async function firmarXML(
+  xmlString: string,
+  p12Path: string,
+  password: string,
+  tipoDocumento: TipoDocumento = '01',
+): Promise<string> {
   try {
-    // Read PEM file
-    const pemData = fs.readFileSync(pemPath, 'utf8');
+    const p12Buffer = fs.readFileSync(p12Path);
+    const { certificado, clavePrivada } = extraerCertificadoFirmante(p12Buffer, password || '');
 
-    // Parse the PEM certificate
-    const certPart = pemData.split('-----BEGIN CERTIFICATE-----')[1]?.split('-----END CERTIFICATE-----')[0];
-    if (!certPart) {
-      throw new Error('No se pudo encontrar el certificado en el archivo PEM');
+    // Minimal P12 with only the signing certificate and its key
+    const p12MinimoAsn1 = forge.pkcs12.toPkcs12Asn1(clavePrivada, certificado, password || '');
+    const p12MinimoDer = forge.asn1.toDer(p12MinimoAsn1).getBytes();
+    const p12Minimo = Buffer.from(p12MinimoDer, 'binary');
+
+    const firmador = FIRMADORES[tipoDocumento];
+    if (!firmador) {
+      throw new Error(`Tipo de documento no soportado para firma: ${tipoDocumento}`);
     }
 
-    const certPem = `-----BEGIN CERTIFICATE-----${certPart}-----END CERTIFICATE-----`;
-
-    try {
-      const certificate = forge.pki.certificateFromPem(certPem);
-    } catch (e) {
-      console.error('Error parsing certificate:', e);
-      throw new Error('Error al parsear el certificado: ' + (e as Error).message);
-    }
-
-    // Extract the private key from the certificate
-    let privateKey;
-    let privateKeyPem = '';
-
-    // Check RSA PRIVATE KEY format
-    if (pemData.includes('-----BEGIN RSA PRIVATE KEY-----')) {
-      const rsaKeyPart = pemData.split('-----BEGIN RSA PRIVATE KEY-----')[1]?.split('-----END RSA PRIVATE KEY-----')[0];
-      if (rsaKeyPart) {
-        privateKeyPem = `-----BEGIN RSA PRIVATE KEY-----${rsaKeyPart}-----END RSA PRIVATE KEY-----`;
-        privateKey = privateKeyPem;
-      }
-    }
-    // Check PRIVATE KEY format
-    else if (pemData.includes('-----BEGIN PRIVATE KEY-----')) {
-      const keyPart = pemData.split('-----BEGIN PRIVATE KEY-----')[1]?.split('-----END PRIVATE KEY-----')[0];
-      if (keyPart) {
-        privateKeyPem = `-----BEGIN PRIVATE KEY-----${keyPart}-----END PRIVATE KEY-----`;
-        privateKey = privateKeyPem;
-      }
-    }
-
-    if (!privateKeyPem) {
-      throw new Error('No se encontró la clave privada en el archivo PEM');
-    }
-
-    const sig = new SignedXml({
-      privateKey: privateKey,
-      signatureAlgorithm: 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
-      canonicalizationAlgorithm: 'http://www.w3.org/TR/2001/REC-xml-c14n-20010315',
-    }) as any;
-
-    sig.addReference({
-      xpath: "//*[local-name(.)='factura']",
-      transforms: ['http://www.w3.org/2000/09/xmldsig#enveloped-signature'],
-      digestAlgorithm: 'http://www.w3.org/2000/09/xmldsig#sha1',
-    });
-
-    sig.keyInfoProvider = {
-      getKeyInfo(): string {
-        return `<X509Data><X509Certificate>${certPem
-          .replace('-----BEGIN CERTIFICATE-----', '')
-          .replace('-----END CERTIFICATE-----', '')
-          .replace(/\r?\n|\r/g, '')}</X509Certificate></X509Data>`;
-      },
-    } as KeyInfoProvider;
-
-    // Sign XML
-    const doc = new DOMParser().parseFromString(xmlString, 'text/xml');
-    sig.computeSignature(xmlString);
-    return sig.getSignedXml();
+    return firmador(xmlString, p12Minimo, { pkcs12Password: password || '' });
   } catch (error: any) {
     console.error('Error signing XML:', error.message);
     throw new Error(`Error al firmar XML: ${error.message}`);
@@ -91,7 +131,7 @@ export async function firmarXML(xmlString: string, pemPath: string, password: st
 }
 
 /**
- * Guarda un XML firmado en un archivo
+ * Guarda un XML firmado en el sistema de archivos
  */
 export function guardarXMLFirmado(xmlString: string, outputPath: string): void {
   fs.writeFileSync(outputPath, xmlString, { encoding: 'utf8' });

--- a/src/utils/pdf.utils.ts
+++ b/src/utils/pdf.utils.ts
@@ -5,6 +5,7 @@ import { IProduct } from '../models/Product';
 import { InvoiceRequest } from '../interfaces/invoice.interface';
 import { CreditNoteRequest } from '../interfaces/credit-note.interface';
 import { DebitNoteRequest } from '../interfaces/debit-note.interface';
+import { DeliveryNoteRequest } from '../interfaces/delivery-note.interface';
 
 interface InvoiceData {
   factura: any;
@@ -498,6 +499,203 @@ export async function generateDebitNotePDF(data: DebitNotePDFData): Promise<Buff
   };
 
   return generateInvoicePDF(invoiceShapedData);
+}
+
+export interface DeliveryNotePDFData {
+  guiaRemision: DeliveryNoteRequest;
+  empresa: IIssuingCompany;
+  claveAcceso: string;
+  secuencial: string;
+  fechaEmision: Date;
+  numeroAutorizacion: string;
+  fechaAutorizacion: Date;
+}
+
+/**
+ * Generates an HTML template for the delivery note (guía de remisión) RIDE.
+ * Unlike the other documents it has no monetary values: it describes the
+ * transport and the recipients of the transferred goods.
+ */
+function generateDeliveryNoteHTML(data: DeliveryNotePDFData): string {
+  const { guiaRemision, empresa, claveAcceso, secuencial, numeroAutorizacion, fechaAutorizacion } = data;
+  const info = guiaRemision.infoGuiaRemision;
+
+  const destinatariosHTML = guiaRemision.destinatarios
+    .map((item) => {
+      const dest = item.destinatario;
+      const detallesHTML = dest.detalles
+        .map(
+          (det) => `
+            <tr>
+              <td>${det.detalle.codigoInterno || ''}</td>
+              <td class="text-left">${det.detalle.descripcion}</td>
+              <td class="text-right">${det.detalle.cantidad}</td>
+            </tr>`,
+        )
+        .join('');
+
+      return `
+        <table class="info-table">
+          <tr>
+            <td class="label">Destinatario</td>
+            <td>${dest.razonSocialDestinatario}</td>
+            <td class="label">Identificación</td>
+            <td>${dest.identificacionDestinatario}</td>
+          </tr>
+          <tr>
+            <td class="label">Dirección Destino</td>
+            <td colspan="3">${dest.dirDestinatario}</td>
+          </tr>
+          <tr>
+            <td class="label">Motivo Traslado</td>
+            <td>${dest.motivoTraslado}</td>
+            <td class="label">Ruta</td>
+            <td>${dest.ruta || 'N/A'}</td>
+          </tr>
+          ${
+            dest.numDocSustento
+              ? `<tr>
+            <td class="label">Doc. Sustento</td>
+            <td>${dest.codDocSustento === '01' ? 'FACTURA' : dest.codDocSustento || ''} ${dest.numDocSustento}</td>
+            <td class="label">Fecha Emisión Doc. Sustento</td>
+            <td>${dest.fechaEmisionDocSustento || 'N/A'}</td>
+          </tr>`
+              : ''
+          }
+        </table>
+        <table class="details-table">
+          <thead>
+            <tr>
+              <th style="width: 120px;">Código</th>
+              <th>Descripción</th>
+              <th style="width: 100px;">Cantidad</th>
+            </tr>
+          </thead>
+          <tbody>${detallesHTML}
+          </tbody>
+        </table>`;
+    })
+    .join('');
+
+  return `
+    <!DOCTYPE html>
+    <html lang="es">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>Guía de Remisión Electrónica</title>
+      <style>
+        body { font-family: Arial, sans-serif; font-size: 10px; margin: 0; padding: 10px; line-height: 1.2; }
+        .container { max-width: 800px; margin: 0 auto; }
+        .header { display: flex; border: 1px solid #000; margin-bottom: 10px; }
+        .logo-section { width: 200px; padding: 10px; border-right: 1px solid #000; text-align: center; }
+        .company-info { flex: 1; padding: 10px; }
+        .document-info { width: 200px; padding: 10px; border-left: 1px solid #000; }
+        .no-logo { color: red; font-weight: bold; font-size: 14px; margin-bottom: 10px; }
+        .ruc-box { border: 2px solid #000; padding: 5px; margin: 10px 0; text-align: center; font-weight: bold; }
+        .access-key-number { font-size: 7px; font-family: 'Courier New', monospace; margin: 5px 0; word-spacing: -1px; letter-spacing: 0.5px; line-height: 1.2; width: 100%; overflow-wrap: break-word; }
+        .info-table { width: 100%; border-collapse: collapse; margin-bottom: 10px; }
+        .info-table td { border: 1px solid #000; padding: 3px 5px; font-size: 9px; }
+        .label { background-color: #f0f0f0; font-weight: bold; width: 140px; }
+        .details-table { width: 100%; border-collapse: collapse; margin: 10px 0; }
+        .details-table th, .details-table td { border: 1px solid #000; padding: 3px 5px; text-align: center; font-size: 8px; }
+        .details-table th { background-color: #f0f0f0; font-weight: bold; }
+        .text-left { text-align: left !important; }
+        .text-right { text-align: right !important; }
+      </style>
+    </head>
+    <body>
+      <div class="container">
+        <div class="header">
+          <div class="logo-section">
+            <div class="no-logo">NO TIENE LOGO</div>
+          </div>
+          <div class="company-info">
+            <div style="text-align: center; font-weight: bold; margin-bottom: 10px;">
+              ${empresa.razon_social}
+            </div>
+            <div><strong>Dirección Matriz:</strong> ${empresa.direccion_matriz}</div>
+            <div><strong>Dirección Sucursal:</strong> ${empresa.direccion_establecimiento}</div>
+            <div><strong>OBLIGADO A LLEVAR CONTABILIDAD:</strong> ${empresa.obligado_contabilidad ? 'SI' : 'NO'}</div>
+          </div>
+          <div class="document-info">
+            <div class="ruc-box">R.U.C.: ${empresa.ruc}</div>
+            <div style="text-align: center; font-weight: bold; margin: 10px 0;">GUÍA DE REMISIÓN</div>
+            <div><strong>No.:</strong> ${empresa.codigo_establecimiento}-${empresa.punto_emision}-${secuencial}</div>
+            <div style="margin: 10px 0;">
+              <div><strong>NÚMERO DE AUTORIZACIÓN</strong></div>
+              <div style="word-break: break-all; font-size: 8px;">${numeroAutorizacion}</div>
+            </div>
+            <div><strong>FECHA Y HORA DE AUTORIZACIÓN:</strong></div>
+            <div>${fechaAutorizacion.toLocaleDateString('es-EC')} ${fechaAutorizacion.toLocaleTimeString('es-EC')}</div>
+            <div style="margin-top: 10px;">
+              <div><strong>AMBIENTE:</strong> ${empresa.tipo_ambiente === 1 ? 'PRUEBAS' : 'PRODUCCIÓN'}</div>
+              <div><strong>EMISIÓN:</strong> ${empresa.tipo_emision === 1 ? 'NORMAL' : 'CONTINGENCIA'}</div>
+            </div>
+            <div style="margin-top: 10px;">
+              <div><strong>CLAVE DE ACCESO</strong></div>
+              <div class="access-key-number">${claveAcceso}</div>
+            </div>
+          </div>
+        </div>
+
+        <table class="info-table">
+          <tr>
+            <td class="label">Dirección de Partida</td>
+            <td colspan="3">${info.dirPartida}</td>
+          </tr>
+          <tr>
+            <td class="label">Transportista</td>
+            <td>${info.razonSocialTransportista}</td>
+            <td class="label">Identificación</td>
+            <td>${info.rucTransportista}</td>
+          </tr>
+          <tr>
+            <td class="label">Placa</td>
+            <td>${info.placa}</td>
+            <td class="label">Fecha Inicio / Fin Transporte</td>
+            <td>${info.fechaIniTransporte} - ${info.fechaFinTransporte}</td>
+          </tr>
+        </table>
+
+        ${destinatariosHTML}
+      </div>
+    </body>
+    </html>
+  `;
+}
+
+/**
+ * Generates a PDF buffer for a delivery note (guía de remisión) RIDE
+ */
+export async function generateDeliveryNotePDF(data: DeliveryNotePDFData): Promise<Buffer> {
+  let browser;
+
+  try {
+    browser = await puppeteer.launch({
+      headless: true,
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    });
+
+    const page = await browser.newPage();
+    await page.setViewport({ width: 800, height: 1200 });
+    await page.setContent(generateDeliveryNoteHTML(data), { waitUntil: 'networkidle0' });
+
+    const pdfBuffer = await page.pdf({
+      format: 'A4',
+      margin: { top: '10mm', right: '10mm', bottom: '10mm', left: '10mm' },
+      printBackground: true,
+    });
+
+    return Buffer.from(pdfBuffer);
+  } catch (error) {
+    console.error('Error generating PDF:', error);
+    throw new Error(`Failed to generate PDF: ${(error as Error).message}`);
+  } finally {
+    if (browser) {
+      await browser.close();
+    }
+  }
 }
 
 /**

--- a/src/utils/pdf.utils.ts
+++ b/src/utils/pdf.utils.ts
@@ -4,6 +4,7 @@ import { IClient } from '../models/Client';
 import { IProduct } from '../models/Product';
 import { InvoiceRequest } from '../interfaces/invoice.interface';
 import { CreditNoteRequest } from '../interfaces/credit-note.interface';
+import { DebitNoteRequest } from '../interfaces/debit-note.interface';
 
 interface InvoiceData {
   factura: any;
@@ -31,6 +32,17 @@ export interface CreditNotePDFData {
   empresa: IIssuingCompany;
   cliente: IClient;
   productos: IProduct[];
+  claveAcceso: string;
+  secuencial: string;
+  fechaEmision: Date;
+  numeroAutorizacion: string;
+  fechaAutorizacion: Date;
+}
+
+export interface DebitNotePDFData {
+  notaDebito: DebitNoteRequest;
+  empresa: IIssuingCompany;
+  cliente: IClient;
   claveAcceso: string;
   secuencial: string;
   fechaEmision: Date;
@@ -437,6 +449,51 @@ export async function generateCreditNotePDF(data: CreditNotePDFData): Promise<Bu
       numero: info.numDocModificado,
       fechaEmision: info.fechaEmisionDocSustento,
       motivo: info.motivo,
+    },
+  };
+
+  return generateInvoicePDF(invoiceShapedData);
+}
+
+/**
+ * Generates a PDF buffer for a debit note (RIDE) reusing the shared document template.
+ * The motivos (surcharges) are rendered as the document line items.
+ */
+export async function generateDebitNotePDF(data: DebitNotePDFData): Promise<Buffer> {
+  const info = data.notaDebito.infoNotaDebito;
+  const motivoPrincipal = data.notaDebito.motivos[0]?.motivo.razon || '';
+
+  const invoiceShapedData: InvoiceData = {
+    factura: {
+      infoFactura: {
+        totalSinImpuestos: info.totalSinImpuestos,
+        importeTotal: info.valorTotal,
+      },
+      detalles: data.notaDebito.motivos.map((item) => ({
+        detalle: {
+          codigoPrincipal: '',
+          descripcion: item.motivo.razon,
+          cantidad: '1',
+          precioUnitario: item.motivo.valor,
+          precioTotalSinImpuesto: item.motivo.valor,
+          impuestos: info.impuestos,
+        },
+      })),
+    },
+    empresa: data.empresa,
+    cliente: data.cliente,
+    productos: data.notaDebito.motivos.map(() => ({}) as IProduct),
+    claveAcceso: data.claveAcceso,
+    secuencial: data.secuencial,
+    fechaEmision: data.fechaEmision,
+    numeroAutorizacion: data.numeroAutorizacion,
+    fechaAutorizacion: data.fechaAutorizacion,
+    tipoDocumento: 'NOTA DE DÉBITO',
+    docModificado: {
+      tipo: info.codDocModificado === '01' ? 'FACTURA' : info.codDocModificado,
+      numero: info.numDocModificado,
+      fechaEmision: info.fechaEmisionDocSustento,
+      motivo: motivoPrincipal,
     },
   };
 

--- a/src/utils/pdf.utils.ts
+++ b/src/utils/pdf.utils.ts
@@ -3,9 +3,31 @@ import { IIssuingCompany } from '../models/IssuingCompany';
 import { IClient } from '../models/Client';
 import { IProduct } from '../models/Product';
 import { InvoiceRequest } from '../interfaces/invoice.interface';
+import { CreditNoteRequest } from '../interfaces/credit-note.interface';
 
 interface InvoiceData {
   factura: any;
+  empresa: IIssuingCompany;
+  cliente: IClient;
+  productos: IProduct[];
+  claveAcceso: string;
+  secuencial: string;
+  fechaEmision: Date;
+  numeroAutorizacion: string;
+  fechaAutorizacion: Date;
+  /** Título del documento en el RIDE. Por defecto 'FACTURA' */
+  tipoDocumento?: string;
+  /** Información del documento que se modifica (solo notas de crédito/débito) */
+  docModificado?: {
+    tipo: string;
+    numero: string;
+    fechaEmision: string;
+    motivo: string;
+  };
+}
+
+export interface CreditNotePDFData {
+  notaCredito: CreditNoteRequest;
   empresa: IIssuingCompany;
   cliente: IClient;
   productos: IProduct[];
@@ -31,6 +53,22 @@ function generateInvoiceHTML(data: InvoiceData): string {
     numeroAutorizacion,
     fechaAutorizacion,
   } = data;
+
+  const tituloDocumento = data.tipoDocumento || 'FACTURA';
+  const tarifaIva = process.env.IVA || '15';
+  const filasDocModificado = data.docModificado
+    ? `
+          <tr>
+            <td class="label">Comprobante que se modifica</td>
+            <td>${data.docModificado.tipo} ${data.docModificado.numero}</td>
+            <td class="label">Fecha Emisión (Doc. Sustento)</td>
+            <td>${data.docModificado.fechaEmision}</td>
+          </tr>
+          <tr>
+            <td class="label">Razón de Modificación</td>
+            <td colspan="3">${data.docModificado.motivo}</td>
+          </tr>`
+    : '';
 
   return `
     <!DOCTYPE html>
@@ -177,7 +215,7 @@ function generateInvoiceHTML(data: InvoiceData): string {
               R.U.C.: ${empresa.ruc}
             </div>
             <div style="text-align: center; font-weight: bold; margin: 10px 0;">
-              FACTURA
+              ${tituloDocumento}
             </div>
             <div><strong>No.:</strong> ${empresa.codigo_establecimiento}-${empresa.punto_emision}-${secuencial}</div>
             <div style="margin: 10px 0;">
@@ -214,7 +252,7 @@ function generateInvoiceHTML(data: InvoiceData): string {
           <tr>
             <td class="label">Dirección</td>
             <td colspan="3">${cliente.direccion || 'N/A'}</td>
-          </tr>
+          </tr>${filasDocModificado}
         </table>
 
         <!-- Invoice Details -->
@@ -265,7 +303,7 @@ function generateInvoiceHTML(data: InvoiceData): string {
         <div class="totals-section">
           <table class="totals-table">
             <tr>
-              <td class="label">SUBTOTAL 12%</td>
+              <td class="label">SUBTOTAL ${tarifaIva}%</td>
               <td class="amount">$${parseFloat(factura.infoFactura.totalSinImpuestos).toFixed(2)}</td>
             </tr>
             <tr>
@@ -285,7 +323,7 @@ function generateInvoiceHTML(data: InvoiceData): string {
               <td class="amount">$0.00</td>
             </tr>
             <tr>
-              <td class="label">IVA 12%</td>
+              <td class="label">IVA ${tarifaIva}%</td>
               <td class="amount">$${(parseFloat(factura.infoFactura.importeTotal) - parseFloat(factura.infoFactura.totalSinImpuestos)).toFixed(2)}</td>
             </tr>
             <tr>
@@ -359,6 +397,50 @@ export async function generateInvoicePDF(invoiceData: InvoiceData): Promise<Buff
       await browser.close();
     }
   }
+}
+
+/**
+ * Generates a PDF buffer for a credit note (RIDE) reusing the shared document template
+ */
+export async function generateCreditNotePDF(data: CreditNotePDFData): Promise<Buffer> {
+  const info = data.notaCredito.infoNotaCredito;
+
+  // Map the credit note into the shared document template shape
+  const invoiceShapedData: InvoiceData = {
+    factura: {
+      infoFactura: {
+        totalSinImpuestos: info.totalSinImpuestos,
+        importeTotal: info.valorModificacion,
+      },
+      detalles: data.notaCredito.detalles.map((item) => ({
+        detalle: {
+          codigoPrincipal: item.detalle.codigoInterno,
+          descripcion: item.detalle.descripcion,
+          cantidad: item.detalle.cantidad,
+          precioUnitario: item.detalle.precioUnitario,
+          precioTotalSinImpuesto: item.detalle.precioTotalSinImpuesto,
+          impuestos: item.detalle.impuestos,
+        },
+      })),
+    },
+    empresa: data.empresa,
+    cliente: data.cliente,
+    productos: data.productos,
+    claveAcceso: data.claveAcceso,
+    secuencial: data.secuencial,
+    fechaEmision: data.fechaEmision,
+    numeroAutorizacion: data.numeroAutorizacion,
+    fechaAutorizacion: data.fechaAutorizacion,
+    tipoDocumento: 'NOTA DE CRÉDITO',
+    docModificado: {
+      tipo: info.codDocModificado === '01' ? 'FACTURA' : info.codDocModificado,
+      numero: info.numDocModificado,
+      fechaEmision: info.fechaEmisionDocSustento,
+      motivo: info.motivo,
+    },
+  };
+
+  return generateInvoicePDF(invoiceShapedData);
 }
 
 /**

--- a/src/utils/pdf.utils.ts
+++ b/src/utils/pdf.utils.ts
@@ -6,6 +6,7 @@ import { InvoiceRequest } from '../interfaces/invoice.interface';
 import { CreditNoteRequest } from '../interfaces/credit-note.interface';
 import { DebitNoteRequest } from '../interfaces/debit-note.interface';
 import { DeliveryNoteRequest } from '../interfaces/delivery-note.interface';
+import { WithholdingRequest } from '../interfaces/withholding.interface';
 
 interface InvoiceData {
   factura: any;
@@ -680,6 +681,190 @@ export async function generateDeliveryNotePDF(data: DeliveryNotePDFData): Promis
     const page = await browser.newPage();
     await page.setViewport({ width: 800, height: 1200 });
     await page.setContent(generateDeliveryNoteHTML(data), { waitUntil: 'networkidle0' });
+
+    const pdfBuffer = await page.pdf({
+      format: 'A4',
+      margin: { top: '10mm', right: '10mm', bottom: '10mm', left: '10mm' },
+      printBackground: true,
+    });
+
+    return Buffer.from(pdfBuffer);
+  } catch (error) {
+    console.error('Error generating PDF:', error);
+    throw new Error(`Failed to generate PDF: ${(error as Error).message}`);
+  } finally {
+    if (browser) {
+      await browser.close();
+    }
+  }
+}
+
+export interface WithholdingPDFData {
+  retencion: WithholdingRequest;
+  empresa: IIssuingCompany;
+  claveAcceso: string;
+  secuencial: string;
+  fechaEmision: Date;
+  numeroAutorizacion: string;
+  fechaAutorizacion: Date;
+}
+
+/**
+ * Generates an HTML template for the withholding certificate RIDE
+ * (printed format of version 1.0.0, as indicated in Anexo 10)
+ */
+function generateWithholdingHTML(data: WithholdingPDFData): string {
+  const { retencion, empresa, claveAcceso, secuencial, numeroAutorizacion, fechaAutorizacion } = data;
+  const info = retencion.infoCompRetencion;
+
+  const IMPUESTOS: Record<string, string> = { '1': 'RENTA', '2': 'IVA', '6': 'ISD' };
+
+  const filasRetenciones = retencion.docsSustento
+    .flatMap((item) => {
+      const ds = item.docSustento;
+      const docLabel = `${ds.codDocSustento === '01' ? 'FACTURA' : ds.codDocSustento} ${ds.numDocSustento || ''}`;
+      return ds.retenciones.map(
+        (ret) => `
+            <tr>
+              <td>${docLabel}</td>
+              <td>${ds.fechaEmisionDocSustento}</td>
+              <td>${IMPUESTOS[ret.retencion.codigo] || ret.retencion.codigo}</td>
+              <td>${ret.retencion.codigoRetencion}</td>
+              <td class="text-right">$${parseFloat(ret.retencion.baseImponible).toFixed(2)}</td>
+              <td class="text-right">${ret.retencion.porcentajeRetener}%</td>
+              <td class="text-right">$${parseFloat(ret.retencion.valorRetenido).toFixed(2)}</td>
+            </tr>`,
+      );
+    })
+    .join('');
+
+  const totalRetenido = retencion.docsSustento
+    .flatMap((item) => item.docSustento.retenciones)
+    .reduce((s, r) => s + parseFloat(r.retencion.valorRetenido), 0)
+    .toFixed(2);
+
+  return `
+    <!DOCTYPE html>
+    <html lang="es">
+    <head>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <title>Comprobante de Retención Electrónico</title>
+      <style>
+        body { font-family: Arial, sans-serif; font-size: 10px; margin: 0; padding: 10px; line-height: 1.2; }
+        .container { max-width: 800px; margin: 0 auto; }
+        .header { display: flex; border: 1px solid #000; margin-bottom: 10px; }
+        .logo-section { width: 200px; padding: 10px; border-right: 1px solid #000; text-align: center; }
+        .company-info { flex: 1; padding: 10px; }
+        .document-info { width: 200px; padding: 10px; border-left: 1px solid #000; }
+        .no-logo { color: red; font-weight: bold; font-size: 14px; margin-bottom: 10px; }
+        .ruc-box { border: 2px solid #000; padding: 5px; margin: 10px 0; text-align: center; font-weight: bold; }
+        .access-key-number { font-size: 7px; font-family: 'Courier New', monospace; margin: 5px 0; word-spacing: -1px; letter-spacing: 0.5px; line-height: 1.2; width: 100%; overflow-wrap: break-word; }
+        .info-table { width: 100%; border-collapse: collapse; margin-bottom: 10px; }
+        .info-table td { border: 1px solid #000; padding: 3px 5px; font-size: 9px; }
+        .label { background-color: #f0f0f0; font-weight: bold; width: 140px; }
+        .details-table { width: 100%; border-collapse: collapse; margin: 10px 0; }
+        .details-table th, .details-table td { border: 1px solid #000; padding: 3px 5px; text-align: center; font-size: 8px; }
+        .details-table th { background-color: #f0f0f0; font-weight: bold; }
+        .text-right { text-align: right !important; }
+        .totals-table { width: 300px; margin-left: auto; border-collapse: collapse; }
+        .totals-table td { border: 1px solid #000; padding: 3px 5px; font-size: 9px; }
+        .amount { text-align: right; font-weight: bold; }
+      </style>
+    </head>
+    <body>
+      <div class="container">
+        <div class="header">
+          <div class="logo-section">
+            <div class="no-logo">NO TIENE LOGO</div>
+          </div>
+          <div class="company-info">
+            <div style="text-align: center; font-weight: bold; margin-bottom: 10px;">
+              ${empresa.razon_social}
+            </div>
+            <div><strong>Dirección Matriz:</strong> ${empresa.direccion_matriz}</div>
+            <div><strong>Dirección Sucursal:</strong> ${empresa.direccion_establecimiento}</div>
+            <div><strong>OBLIGADO A LLEVAR CONTABILIDAD:</strong> ${empresa.obligado_contabilidad ? 'SI' : 'NO'}</div>
+          </div>
+          <div class="document-info">
+            <div class="ruc-box">R.U.C.: ${empresa.ruc}</div>
+            <div style="text-align: center; font-weight: bold; margin: 10px 0;">COMPROBANTE DE RETENCIÓN</div>
+            <div><strong>No.:</strong> ${empresa.codigo_establecimiento}-${empresa.punto_emision}-${secuencial}</div>
+            <div style="margin: 10px 0;">
+              <div><strong>NÚMERO DE AUTORIZACIÓN</strong></div>
+              <div style="word-break: break-all; font-size: 8px;">${numeroAutorizacion}</div>
+            </div>
+            <div><strong>FECHA Y HORA DE AUTORIZACIÓN:</strong></div>
+            <div>${fechaAutorizacion.toLocaleDateString('es-EC')} ${fechaAutorizacion.toLocaleTimeString('es-EC')}</div>
+            <div style="margin-top: 10px;">
+              <div><strong>AMBIENTE:</strong> ${empresa.tipo_ambiente === 1 ? 'PRUEBAS' : 'PRODUCCIÓN'}</div>
+              <div><strong>EMISIÓN:</strong> ${empresa.tipo_emision === 1 ? 'NORMAL' : 'CONTINGENCIA'}</div>
+            </div>
+            <div style="margin-top: 10px;">
+              <div><strong>CLAVE DE ACCESO</strong></div>
+              <div class="access-key-number">${claveAcceso}</div>
+            </div>
+          </div>
+        </div>
+
+        <table class="info-table">
+          <tr>
+            <td class="label">Razón Social Sujeto Retenido</td>
+            <td>${info.razonSocialSujetoRetenido}</td>
+            <td class="label">Identificación</td>
+            <td>${info.identificacionSujetoRetenido}</td>
+          </tr>
+          <tr>
+            <td class="label">Fecha Emisión</td>
+            <td>${info.fechaEmision}</td>
+            <td class="label">Período Fiscal</td>
+            <td>${info.periodoFiscal}</td>
+          </tr>
+        </table>
+
+        <table class="details-table">
+          <thead>
+            <tr>
+              <th>Comprobante</th>
+              <th>Fecha Emisión</th>
+              <th>Impuesto</th>
+              <th>Código Retención</th>
+              <th>Base Imponible</th>
+              <th>% Retención</th>
+              <th>Valor Retenido</th>
+            </tr>
+          </thead>
+          <tbody>${filasRetenciones}
+          </tbody>
+        </table>
+
+        <table class="totals-table">
+          <tr>
+            <td class="label" style="font-weight: bold;">TOTAL RETENIDO</td>
+            <td class="amount" style="font-size: 11px;">$${totalRetenido}</td>
+          </tr>
+        </table>
+      </div>
+    </body>
+    </html>
+  `;
+}
+
+/**
+ * Generates a PDF buffer for a withholding certificate RIDE
+ */
+export async function generateWithholdingPDF(data: WithholdingPDFData): Promise<Buffer> {
+  let browser;
+
+  try {
+    browser = await puppeteer.launch({
+      headless: true,
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    });
+
+    const page = await browser.newPage();
+    await page.setViewport({ width: 800, height: 1200 });
+    await page.setContent(generateWithholdingHTML(data), { waitUntil: 'networkidle0' });
 
     const pdfBuffer = await page.pdf({
       format: 'A4',

--- a/src/utils/sri.utils.ts
+++ b/src/utils/sri.utils.ts
@@ -44,6 +44,15 @@ export interface RespuestaSRI {
   };
 }
 
+// Interface for SRI authorization response
+export interface AutorizacionSRI {
+  estado: string; // EX: AUTORIZADO, NO AUTORIZADO, EN PROCESO
+  numeroAutorizacion?: string;
+  fechaAutorizacion?: string;
+  ambiente?: string;
+  mensajes?: RespuestaSRI['mensajes'];
+}
+
 // WSDL URLs for SRI - now configurable via environment variables
 const WSDL_PRUEBAS_RECEPCION =
   process.env.SRI_RECEPCION_URL_PRUEBAS ||
@@ -53,12 +62,28 @@ const WSDL_PRODUCCION_RECEPCION =
   process.env.SRI_RECEPCION_URL_PRODUCCION ||
   'https://cel.sri.gob.ec/comprobantes-electronicos-ws/RecepcionComprobantesOffline?wsdl';
 
+const WSDL_PRUEBAS_AUTORIZACION =
+  process.env.SRI_AUTORIZACION_URL_PRUEBAS ||
+  'https://celcer.sri.gob.ec/comprobantes-electronicos-ws/AutorizacionComprobantesOffline?wsdl';
+
+const WSDL_PRODUCCION_AUTORIZACION =
+  process.env.SRI_AUTORIZACION_URL_PRODUCCION ||
+  'https://cel.sri.gob.ec/comprobantes-electronicos-ws/AutorizacionComprobantesOffline?wsdl';
+
 /**
  * Get the appropriate WSDL URL based on environment
  */
 function getWsdlUrl(): string {
   const environment = process.env.SRI_ENVIRONMENT || '1';
   return environment === '2' ? WSDL_PRODUCCION_RECEPCION : WSDL_PRUEBAS_RECEPCION;
+}
+
+/**
+ * Get the appropriate authorization WSDL URL based on environment
+ */
+function getAutorizacionWsdlUrl(): string {
+  const environment = process.env.SRI_ENVIRONMENT || '1';
+  return environment === '2' ? WSDL_PRODUCCION_AUTORIZACION : WSDL_PRUEBAS_AUTORIZACION;
 }
 
 /**
@@ -228,9 +253,165 @@ export async function enviarComprobanteSRI(xmlFirmado: string): Promise<Respuest
   }
 }
 
-// Helper to remove XML tag prefixes when parsing (if using xml2js)
-/*
-function stripPrefix(name: string): string {
-  return name.substring(name.indexOf(':') + 1);
+/**
+ * Extracts the mensajes block from an XML element, if present
+ */
+function extraerMensajes(parent: Element | Document): RespuestaSRI['mensajes'] | undefined {
+  const mensajesElements = parent.getElementsByTagName('mensaje');
+  if (mensajesElements.length === 0) return undefined;
+
+  const mensajes = [];
+  for (let i = 0; i < mensajesElements.length; i++) {
+    const mensajeElement = mensajesElements[i];
+
+    // Skip the inner <mensaje> text element nested inside a <mensaje> entry
+    if (mensajeElement.parentNode?.nodeName === 'mensaje') {
+      continue;
+    }
+
+    const identificador = mensajeElement.getElementsByTagName('identificador')[0]?.textContent || '';
+    const mensaje = mensajeElement.getElementsByTagName('mensaje')[0]?.textContent || '';
+    const tipo = mensajeElement.getElementsByTagName('tipo')[0]?.textContent || 'INFO';
+    const informacionAdicional = mensajeElement.getElementsByTagName('informacionAdicional')[0]?.textContent;
+
+    mensajes.push({
+      identificador,
+      mensaje,
+      tipo,
+      ...(informacionAdicional && { informacionAdicional }),
+    });
+  }
+
+  if (mensajes.length === 0) return undefined;
+
+  return mensajes.length === 1 ? { mensaje: mensajes[0] } : { mensaje: mensajes };
 }
-*/
+
+/**
+ * Parse the SRI authorization XML response into an AutorizacionSRI object
+ */
+function parseAutorizacionResponse(xmlString: string): AutorizacionSRI {
+  try {
+    const parser = new DOMParser();
+    const xmlDoc = parser.parseFromString(xmlString, 'text/xml');
+
+    const faultElements = xmlDoc.getElementsByTagName('soap:Fault');
+    if (faultElements.length > 0) {
+      const faultString =
+        faultElements[0].getElementsByTagName('faultstring')[0]?.textContent || 'Error SOAP desconocido';
+      return {
+        estado: 'ERROR_SOAP',
+        mensajes: {
+          mensaje: { identificador: '001', mensaje: `Error SOAP: ${faultString}`, tipo: 'ERROR' },
+        },
+      };
+    }
+
+    const autorizacionElement = xmlDoc.getElementsByTagName('autorizacion')[0];
+    if (!autorizacionElement) {
+      // The SRI may respond without an autorizacion node while the receipt is still in process
+      return { estado: 'EN PROCESO' };
+    }
+
+    const estado = autorizacionElement.getElementsByTagName('estado')[0]?.textContent || 'DESCONOCIDO';
+    const numeroAutorizacion = autorizacionElement.getElementsByTagName('numeroAutorizacion')[0]?.textContent;
+    const fechaAutorizacion = autorizacionElement.getElementsByTagName('fechaAutorizacion')[0]?.textContent;
+    const ambiente = autorizacionElement.getElementsByTagName('ambiente')[0]?.textContent;
+
+    return {
+      estado,
+      ...(numeroAutorizacion && { numeroAutorizacion }),
+      ...(fechaAutorizacion && { fechaAutorizacion }),
+      ...(ambiente && { ambiente }),
+      ...(extraerMensajes(autorizacionElement) && { mensajes: extraerMensajes(autorizacionElement) }),
+    };
+  } catch (error) {
+    return {
+      estado: 'ERROR_PARSING',
+      mensajes: {
+        mensaje: {
+          identificador: '001',
+          mensaje: 'Error al procesar respuesta de autorización del SRI',
+          tipo: 'ERROR',
+        },
+      },
+    };
+  }
+}
+
+/**
+ * Queries the SRI authorization web service for a receipt by its access key.
+ * In the offline scheme the authorization number equals the access key.
+ * @param claveAcceso 49-digit access key of the receipt.
+ * @returns Promise<AutorizacionSRI> The parsed authorization response.
+ */
+export async function autorizarComprobanteSRI(claveAcceso: string): Promise<AutorizacionSRI> {
+  try {
+    const soapRequestBody =
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+      '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ec="http://ec.gob.sri.ws.autorizacion">' +
+      '<soap:Header/>' +
+      '<soap:Body>' +
+      '<ec:autorizacionComprobante>' +
+      '<claveAccesoComprobante>' +
+      claveAcceso +
+      '</claveAccesoComprobante>' +
+      '</ec:autorizacionComprobante>' +
+      '</soap:Body>' +
+      '</soap:Envelope>';
+
+    const possibleActions = [
+      '"http://ec.gob.sri.ws.autorizacion/autorizacionComprobante"',
+      '"autorizacionComprobante"',
+      '""',
+    ];
+
+    for (const soapAction of possibleActions) {
+      try {
+        const headers: Record<string, string> = {
+          'Content-Type': 'text/xml; charset=utf-8',
+        };
+
+        if (soapAction && soapAction !== '""') {
+          headers['SOAPAction'] = soapAction;
+        }
+
+        const response = await axios.post(getAutorizacionWsdlUrl(), soapRequestBody, {
+          headers,
+          timeout: 30000,
+        });
+
+        if (typeof response.data === 'string') {
+          const result = parseAutorizacionResponse(response.data);
+          if (result.estado !== 'ERROR_SOAP') {
+            return result;
+          }
+        }
+      } catch (error: any) {
+        continue;
+      }
+    }
+
+    return {
+      estado: 'ERROR_COMUNICACION',
+      mensajes: {
+        mensaje: {
+          identificador: '000',
+          mensaje: 'No se pudo determinar el SOAPAction correcto para el servicio de autorización del SRI',
+          tipo: 'ERROR',
+        },
+      },
+    };
+  } catch (error: any) {
+    return {
+      estado: 'ERROR_COMUNICACION',
+      mensajes: {
+        mensaje: {
+          identificador: '000',
+          mensaje: `Error de comunicación con SRI: ${error.message}`,
+          tipo: 'ERROR',
+        },
+      },
+    };
+  }
+}

--- a/src/utils/sri.utils.ts
+++ b/src/utils/sri.utils.ts
@@ -126,29 +126,9 @@ function parseXmlResponse(xmlString: string): RespuestaSRI {
     const respuesta: RespuestaSRI = { estado };
 
     // Extract mensajes if they exist
-    const mensajesElements = xmlDoc.getElementsByTagName('mensaje');
-    if (mensajesElements.length > 0) {
-      const mensajes = [];
-      for (let i = 0; i < mensajesElements.length; i++) {
-        const mensajeElement = mensajesElements[i];
-        const identificador = mensajeElement.getElementsByTagName('identificador')[0]?.textContent || '';
-        const mensaje = mensajeElement.getElementsByTagName('mensaje')[0]?.textContent || '';
-        const tipo = mensajeElement.getElementsByTagName('tipo')[0]?.textContent || 'INFO';
-        const informacionAdicional = mensajeElement.getElementsByTagName('informacionAdicional')[0]?.textContent;
-
-        mensajes.push({
-          identificador,
-          mensaje,
-          tipo,
-          ...(informacionAdicional && { informacionAdicional }),
-        });
-      }
-
-      if (mensajes.length === 1) {
-        respuesta.mensajes = { mensaje: mensajes[0] };
-      } else if (mensajes.length > 1) {
-        respuesta.mensajes = { mensaje: mensajes };
-      }
+    const mensajesExtraidos = extraerMensajes(xmlDoc);
+    if (mensajesExtraidos) {
+      respuesta.mensajes = mensajesExtraidos;
     }
 
     // Extract comprobantes if they exist

--- a/src/utils/xml.utils.ts
+++ b/src/utils/xml.utils.ts
@@ -5,6 +5,7 @@ import { IProduct } from '../models/Product';
 import { InvoiceRequest } from '../interfaces/invoice.interface';
 import { CreditNoteRequest } from '../interfaces/credit-note.interface';
 import { DebitNoteRequest } from '../interfaces/debit-note.interface';
+import { DeliveryNoteRequest } from '../interfaces/delivery-note.interface';
 
 /**
  * IVA configuration (tabla 17 de la Ficha Técnica del SRI).
@@ -530,6 +531,153 @@ export function generarXMLNotaDebito(
     .ele('campoAdicional', { nombre: 'Teléfono' })
     .txt(cliente.telefono || '0000000000')
     .up();
+
+  return doc.end({ prettyPrint: true });
+}
+
+/**
+ * Genera un documento XML para una guía de remisión electrónica según el formato
+ * v1.1.0 de la Ficha Técnica del SRI de Ecuador (codDoc 06).
+ * Documento sin valores monetarios: describe el transporte y los destinatarios.
+ * @param guiaRemision Datos de la guía de remisión
+ * @param empresa Empresa emisora
+ * @param claveAcceso Clave de acceso generada
+ * @param secuencial Número secuencial de la guía de remisión
+ * @returns XML de la guía de remisión como string
+ */
+export function generarXMLGuiaRemision(
+  guiaRemision: DeliveryNoteRequest,
+  empresa: IIssuingCompany,
+  claveAcceso: string,
+  secuencial: string,
+): string {
+  const info = guiaRemision.infoGuiaRemision;
+
+  const doc = create({ version: '1.0', encoding: 'UTF-8' })
+    .ele('guiaRemision', {
+      id: 'comprobante',
+      version: '1.1.0',
+    })
+    .ele('infoTributaria')
+    .ele('ambiente')
+    .txt(String(empresa.tipo_ambiente))
+    .up()
+    .ele('tipoEmision')
+    .txt(String(empresa.tipo_emision))
+    .up()
+    .ele('razonSocial')
+    .txt(empresa.razon_social)
+    .up()
+    .ele('nombreComercial')
+    .txt(empresa.nombre_comercial)
+    .up()
+    .ele('ruc')
+    .txt(empresa.ruc)
+    .up()
+    .ele('claveAcceso')
+    .txt(claveAcceso)
+    .up()
+    .ele('codDoc')
+    .txt('06')
+    .up() // guía de remisión
+    .ele('estab')
+    .txt(empresa.codigo_establecimiento)
+    .up()
+    .ele('ptoEmi')
+    .txt(empresa.punto_emision)
+    .up()
+    .ele('secuencial')
+    .txt(secuencial)
+    .up()
+    .ele('dirMatriz')
+    .txt(empresa.direccion_matriz || empresa.direccion || 'Dirección no especificada')
+    .up()
+    .up()
+    .ele('infoGuiaRemision')
+    .ele('dirEstablecimiento')
+    .txt(empresa.direccion_establecimiento || empresa.direccion || 'Dirección no especificada')
+    .up()
+    .ele('dirPartida')
+    .txt(info.dirPartida)
+    .up()
+    .ele('razonSocialTransportista')
+    .txt(info.razonSocialTransportista)
+    .up()
+    .ele('tipoIdentificacionTransportista')
+    .txt(info.tipoIdentificacionTransportista)
+    .up()
+    .ele('rucTransportista')
+    .txt(info.rucTransportista)
+    .up()
+    .ele('obligadoContabilidad')
+    .txt(empresa.obligado_contabilidad ? 'SI' : 'NO')
+    .up()
+    .ele('fechaIniTransporte')
+    .txt(info.fechaIniTransporte)
+    .up()
+    .ele('fechaFinTransporte')
+    .txt(info.fechaFinTransporte)
+    .up()
+    .ele('placa')
+    .txt(info.placa)
+    .up()
+    .up()
+    .ele('destinatarios');
+
+  // Cursor tracking: xmlbuilder2 returns a new node reference on each call,
+  // so nested loops must build from an explicitly captured parent node
+  for (const item of guiaRemision.destinatarios) {
+    const dest = item.destinatario;
+    const destNode = doc
+      .ele('destinatario')
+      .ele('identificacionDestinatario')
+      .txt(dest.identificacionDestinatario)
+      .up()
+      .ele('razonSocialDestinatario')
+      .txt(dest.razonSocialDestinatario)
+      .up()
+      .ele('dirDestinatario')
+      .txt(dest.dirDestinatario)
+      .up()
+      .ele('motivoTraslado')
+      .txt(dest.motivoTraslado)
+      .up();
+
+    if (dest.docAduaneroUnico) {
+      destNode.ele('docAduaneroUnico').txt(dest.docAduaneroUnico).up();
+    }
+    if (dest.codEstabDestino) {
+      destNode.ele('codEstabDestino').txt(dest.codEstabDestino).up();
+    }
+    if (dest.ruta) {
+      destNode.ele('ruta').txt(dest.ruta).up();
+    }
+    if (dest.codDocSustento) {
+      destNode.ele('codDocSustento').txt(dest.codDocSustento).up();
+    }
+    if (dest.numDocSustento) {
+      destNode.ele('numDocSustento').txt(dest.numDocSustento).up();
+    }
+    if (dest.numAutDocSustento) {
+      destNode.ele('numAutDocSustento').txt(dest.numAutDocSustento).up();
+    }
+    if (dest.fechaEmisionDocSustento) {
+      destNode.ele('fechaEmisionDocSustento').txt(dest.fechaEmisionDocSustento).up();
+    }
+
+    const detallesNode = destNode.ele('detalles');
+    for (const det of dest.detalles) {
+      const d = det.detalle;
+      const detalleNode = detallesNode.ele('detalle');
+      if (d.codigoInterno) {
+        detalleNode.ele('codigoInterno').txt(d.codigoInterno).up();
+      }
+      if (d.codigoAdicional) {
+        detalleNode.ele('codigoAdicional').txt(d.codigoAdicional).up();
+      }
+      detalleNode.ele('descripcion').txt(d.descripcion).up().ele('cantidad').txt(d.cantidad).up();
+    }
+  }
 
   return doc.end({ prettyPrint: true });
 }

--- a/src/utils/xml.utils.ts
+++ b/src/utils/xml.utils.ts
@@ -4,6 +4,7 @@ import { IClient } from '../models/Client';
 import { IProduct } from '../models/Product';
 import { InvoiceRequest } from '../interfaces/invoice.interface';
 import { CreditNoteRequest } from '../interfaces/credit-note.interface';
+import { DebitNoteRequest } from '../interfaces/debit-note.interface';
 
 /**
  * IVA configuration (tabla 17 de la Ficha Técnica del SRI).
@@ -363,6 +364,165 @@ export function generarXMLNotaCredito(
 
   doc
     .up() // salir de <detalles>
+    .ele('infoAdicional')
+    .ele('campoAdicional', { nombre: 'Email' })
+    .txt(cliente.email || 'sinfactura@cliente.com')
+    .up()
+    .ele('campoAdicional', { nombre: 'Teléfono' })
+    .txt(cliente.telefono || '0000000000')
+    .up();
+
+  return doc.end({ prettyPrint: true });
+}
+
+/**
+ * Genera un documento XML para una nota de débito electrónica según el formato
+ * v1.0.0 de la Ficha Técnica del SRI de Ecuador (codDoc 05)
+ * @param notaDebito Datos de la nota de débito
+ * @param empresa Empresa emisora
+ * @param cliente Cliente
+ * @param claveAcceso Clave de acceso generada
+ * @param secuencial Número secuencial de la nota de débito
+ * @returns XML de la nota de débito como string
+ */
+export function generarXMLNotaDebito(
+  notaDebito: DebitNoteRequest,
+  empresa: IIssuingCompany,
+  cliente: IClient,
+  claveAcceso: string,
+  secuencial: string,
+): string {
+  const info = notaDebito.infoNotaDebito;
+
+  const doc = create({ version: '1.0', encoding: 'UTF-8' })
+    .ele('notaDebito', {
+      id: 'comprobante',
+      version: '1.0.0',
+    })
+    .ele('infoTributaria')
+    .ele('ambiente')
+    .txt(String(empresa.tipo_ambiente))
+    .up()
+    .ele('tipoEmision')
+    .txt(String(empresa.tipo_emision))
+    .up()
+    .ele('razonSocial')
+    .txt(empresa.razon_social)
+    .up()
+    .ele('nombreComercial')
+    .txt(empresa.nombre_comercial)
+    .up()
+    .ele('ruc')
+    .txt(empresa.ruc)
+    .up()
+    .ele('claveAcceso')
+    .txt(claveAcceso)
+    .up()
+    .ele('codDoc')
+    .txt('05')
+    .up() // nota de débito
+    .ele('estab')
+    .txt(empresa.codigo_establecimiento)
+    .up()
+    .ele('ptoEmi')
+    .txt(empresa.punto_emision)
+    .up()
+    .ele('secuencial')
+    .txt(secuencial)
+    .up()
+    .ele('dirMatriz')
+    .txt(empresa.direccion_matriz || empresa.direccion || 'Dirección no especificada')
+    .up()
+    .up()
+    .ele('infoNotaDebito')
+    .ele('fechaEmision')
+    .txt(info.fechaEmision)
+    .up()
+    .ele('dirEstablecimiento')
+    .txt(empresa.direccion_establecimiento || empresa.direccion || 'Dirección no especificada')
+    .up()
+    .ele('tipoIdentificacionComprador')
+    .txt(info.tipoIdentificacionComprador)
+    .up()
+    .ele('razonSocialComprador')
+    .txt(cliente.razon_social)
+    .up()
+    .ele('identificacionComprador')
+    .txt(cliente.identificacion)
+    .up()
+    .ele('obligadoContabilidad')
+    .txt(empresa.obligado_contabilidad ? 'SI' : 'NO')
+    .up()
+    .ele('codDocModificado')
+    .txt(info.codDocModificado)
+    .up()
+    .ele('numDocModificado')
+    .txt(info.numDocModificado)
+    .up()
+    .ele('fechaEmisionDocSustento')
+    .txt(info.fechaEmisionDocSustento)
+    .up()
+    .ele('totalSinImpuestos')
+    .txt(info.totalSinImpuestos)
+    .up()
+    .ele('impuestos');
+
+  // Tax codes are taken from the request (tablas 16 y 17 de la ficha técnica).
+  // La tarifa de IVA corresponde a la fecha de emisión del documento de sustento.
+  for (const item of info.impuestos) {
+    const impuesto = item.impuesto;
+    doc
+      .ele('impuesto')
+      .ele('codigo')
+      .txt(impuesto.codigo)
+      .up()
+      .ele('codigoPorcentaje')
+      .txt(impuesto.codigoPorcentaje)
+      .up()
+      .ele('tarifa')
+      .txt(impuesto.tarifa)
+      .up()
+      .ele('baseImponible')
+      .txt(impuesto.baseImponible)
+      .up()
+      .ele('valor')
+      .txt(impuesto.valor)
+      .up()
+      .up();
+  }
+
+  // Cursor tracking: xmlbuilder2 returns a new node reference on each call,
+  // so the position after each block must be captured explicitly
+  const pagosNode = doc
+    .up() // salir de <impuestos>
+    .ele('valorTotal')
+    .txt(info.valorTotal)
+    .up()
+    .ele('pagos');
+
+  for (const item of info.pagos) {
+    const pago = item.pago;
+    const pagoNode = pagosNode.ele('pago').ele('formaPago').txt(pago.formaPago).up().ele('total').txt(pago.total).up();
+
+    if (pago.plazo) {
+      pagoNode.ele('plazo').txt(pago.plazo).up();
+    }
+    if (pago.unidadTiempo) {
+      pagoNode.ele('unidadTiempo').txt(pago.unidadTiempo).up();
+    }
+  }
+
+  const motivosNode = pagosNode
+    .up() // salir de <pagos>
+    .up() // salir de <infoNotaDebito>
+    .ele('motivos');
+
+  for (const item of notaDebito.motivos) {
+    motivosNode.ele('motivo').ele('razon').txt(item.motivo.razon).up().ele('valor').txt(item.motivo.valor).up().up();
+  }
+
+  motivosNode
+    .up() // salir de <motivos>
     .ele('infoAdicional')
     .ele('campoAdicional', { nombre: 'Email' })
     .txt(cliente.email || 'sinfactura@cliente.com')

--- a/src/utils/xml.utils.ts
+++ b/src/utils/xml.utils.ts
@@ -759,9 +759,13 @@ export function generarXMLRetencion(
   if (info.tipoSujetoRetenido) {
     infoNode.ele('tipoSujetoRetenido').txt(info.tipoSujetoRetenido).up();
   }
-  if (info.parteRel) {
-    infoNode.ele('parteRel').txt(info.parteRel).up();
-  }
+  // <parteRel> es obligatorio en el esquema de retención ATS 2.0.0 (SI/NO).
+  // Si no se envía en el request se emite 'NO' por defecto, de lo contrario el SRI
+  // devuelve el comprobante con error 35: ARCHIVO NO CUMPLE ESTRUCTURA XML.
+  infoNode
+    .ele('parteRel')
+    .txt(info.parteRel || 'NO')
+    .up();
 
   const docsSustentoNode = infoNode
     .ele('razonSocialSujetoRetenido')

--- a/src/utils/xml.utils.ts
+++ b/src/utils/xml.utils.ts
@@ -3,6 +3,18 @@ import { IIssuingCompany } from '../models/IssuingCompany';
 import { IClient } from '../models/Client';
 import { IProduct } from '../models/Product';
 import { InvoiceRequest } from '../interfaces/invoice.interface';
+import { CreditNoteRequest } from '../interfaces/credit-note.interface';
+
+/**
+ * IVA configuration (tabla 17 de la Ficha Técnica del SRI).
+ * Defaults to the 15% rate in force since April 2024 (codigoPorcentaje 4).
+ */
+export function obtenerConfiguracionIVA(): { tarifa: string; codigoPorcentaje: string } {
+  return {
+    tarifa: process.env.IVA || '15',
+    codigoPorcentaje: process.env.CODIGO_PORCENTAJE || '4',
+  };
+}
 
 /**
  * Genera un documento XML para una factura electrónica según el formato del SRI de Ecuador
@@ -22,6 +34,7 @@ export function generarXMLFactura(
   claveAcceso: string,
   secuencial: string,
 ): string {
+  const iva = obtenerConfiguracionIVA();
   const doc = create({ version: '1.0', encoding: 'UTF-8' })
     .ele('factura', {
       id: 'comprobante',
@@ -93,13 +106,17 @@ export function generarXMLFactura(
     .txt('2')
     .up()
     .ele('codigoPorcentaje')
-    .txt('2')
+    .txt(iva.codigoPorcentaje)
     .up()
     .ele('baseImponible')
     .txt(factura.infoFactura.totalSinImpuestos)
     .up()
     .ele('valor')
-    .txt(productos.reduce((acc, p) => (p.tiene_iva ? acc + 0.12 * p.precio_unitario : acc), 0).toFixed(2))
+    .txt(
+      productos
+        .reduce((acc, p) => (p.tiene_iva ? acc + (parseFloat(iva.tarifa) / 100) * p.precio_unitario : acc), 0)
+        .toFixed(2),
+    )
     .up()
     .up()
     .up()
@@ -144,16 +161,200 @@ export function generarXMLFactura(
       .txt('2')
       .up()
       .ele('codigoPorcentaje')
-      .txt('2')
+      .txt(iva.codigoPorcentaje)
       .up()
       .ele('tarifa')
-      .txt('12.00')
+      .txt(`${iva.tarifa}.00`)
       .up()
       .ele('baseImponible')
       .txt(d.precioTotalSinImpuesto)
       .up()
       .ele('valor')
       .txt(d.impuestos[0].impuesto.valor)
+      .up()
+      .up()
+      .up()
+      .up();
+  }
+
+  doc
+    .up() // salir de <detalles>
+    .ele('infoAdicional')
+    .ele('campoAdicional', { nombre: 'Email' })
+    .txt(cliente.email || 'sinfactura@cliente.com')
+    .up()
+    .ele('campoAdicional', { nombre: 'Teléfono' })
+    .txt(cliente.telefono || '0000000000')
+    .up();
+
+  return doc.end({ prettyPrint: true });
+}
+
+/**
+ * Genera un documento XML para una nota de crédito electrónica según el formato
+ * v1.1.0 de la Ficha Técnica del SRI de Ecuador (codDoc 04)
+ * @param notaCredito Datos de la nota de crédito
+ * @param empresa Empresa emisora
+ * @param cliente Cliente
+ * @param claveAcceso Clave de acceso generada
+ * @param secuencial Número secuencial de la nota de crédito
+ * @returns XML de la nota de crédito como string
+ */
+export function generarXMLNotaCredito(
+  notaCredito: CreditNoteRequest,
+  empresa: IIssuingCompany,
+  cliente: IClient,
+  claveAcceso: string,
+  secuencial: string,
+): string {
+  const info = notaCredito.infoNotaCredito;
+  const totalIva = notaCredito.detalles
+    .reduce((acc, d) => acc + parseFloat(d.detalle.impuestos[0].impuesto.valor), 0)
+    .toFixed(2);
+  // Tax codes are taken from the request details (tablas 16 y 17 de la ficha técnica)
+  const impuestoReferencia = notaCredito.detalles[0].detalle.impuestos[0].impuesto;
+
+  const doc = create({ version: '1.0', encoding: 'UTF-8' })
+    .ele('notaCredito', {
+      id: 'comprobante',
+      version: '1.1.0',
+    })
+    .ele('infoTributaria')
+    .ele('ambiente')
+    .txt(String(empresa.tipo_ambiente))
+    .up()
+    .ele('tipoEmision')
+    .txt(String(empresa.tipo_emision))
+    .up()
+    .ele('razonSocial')
+    .txt(empresa.razon_social)
+    .up()
+    .ele('nombreComercial')
+    .txt(empresa.nombre_comercial)
+    .up()
+    .ele('ruc')
+    .txt(empresa.ruc)
+    .up()
+    .ele('claveAcceso')
+    .txt(claveAcceso)
+    .up()
+    .ele('codDoc')
+    .txt('04')
+    .up() // nota de crédito
+    .ele('estab')
+    .txt(empresa.codigo_establecimiento)
+    .up()
+    .ele('ptoEmi')
+    .txt(empresa.punto_emision)
+    .up()
+    .ele('secuencial')
+    .txt(secuencial)
+    .up()
+    .ele('dirMatriz')
+    .txt(empresa.direccion_matriz || empresa.direccion || 'Dirección no especificada')
+    .up()
+    .up()
+    .ele('infoNotaCredito')
+    .ele('fechaEmision')
+    .txt(info.fechaEmision)
+    .up()
+    .ele('dirEstablecimiento')
+    .txt(empresa.direccion_establecimiento || empresa.direccion || 'Dirección no especificada')
+    .up()
+    .ele('tipoIdentificacionComprador')
+    .txt(info.tipoIdentificacionComprador)
+    .up()
+    .ele('razonSocialComprador')
+    .txt(cliente.razon_social)
+    .up()
+    .ele('identificacionComprador')
+    .txt(cliente.identificacion)
+    .up()
+    .ele('obligadoContabilidad')
+    .txt(empresa.obligado_contabilidad ? 'SI' : 'NO')
+    .up()
+    .ele('codDocModificado')
+    .txt(info.codDocModificado)
+    .up()
+    .ele('numDocModificado')
+    .txt(info.numDocModificado)
+    .up()
+    .ele('fechaEmisionDocSustento')
+    .txt(info.fechaEmisionDocSustento)
+    .up()
+    .ele('totalSinImpuestos')
+    .txt(info.totalSinImpuestos)
+    .up()
+    .ele('valorModificacion')
+    .txt(info.valorModificacion)
+    .up()
+    .ele('moneda')
+    .txt(info.moneda || 'DOLAR')
+    .up()
+    .ele('totalConImpuestos')
+    .ele('totalImpuesto')
+    .ele('codigo')
+    .txt(impuestoReferencia.codigo)
+    .up()
+    .ele('codigoPorcentaje')
+    .txt(impuestoReferencia.codigoPorcentaje)
+    .up()
+    .ele('baseImponible')
+    .txt(info.totalSinImpuestos)
+    .up()
+    .ele('valor')
+    .txt(totalIva)
+    .up()
+    .up()
+    .up()
+    .ele('motivo')
+    .txt(info.motivo)
+    .up()
+    .up()
+    .ele('detalles');
+
+  // Add credit note details
+  for (const item of notaCredito.detalles) {
+    const d = item.detalle;
+    const impuesto = d.impuestos[0].impuesto;
+    const detalle = doc.ele('detalle').ele('codigoInterno').txt(d.codigoInterno).up();
+
+    if (d.codigoAdicional) {
+      detalle.ele('codigoAdicional').txt(d.codigoAdicional).up();
+    }
+
+    detalle
+      .ele('descripcion')
+      .txt(d.descripcion)
+      .up()
+      .ele('cantidad')
+      .txt(d.cantidad)
+      .up()
+      .ele('precioUnitario')
+      .txt(d.precioUnitario)
+      .up()
+      .ele('descuento')
+      .txt(d.descuento || '0.00')
+      .up()
+      .ele('precioTotalSinImpuesto')
+      .txt(d.precioTotalSinImpuesto)
+      .up()
+      .ele('impuestos')
+      .ele('impuesto')
+      .ele('codigo')
+      .txt(impuesto.codigo)
+      .up()
+      .ele('codigoPorcentaje')
+      .txt(impuesto.codigoPorcentaje)
+      .up()
+      .ele('tarifa')
+      .txt(impuesto.tarifa)
+      .up()
+      .ele('baseImponible')
+      .txt(impuesto.baseImponible)
+      .up()
+      .ele('valor')
+      .txt(impuesto.valor)
       .up()
       .up()
       .up()

--- a/src/utils/xml.utils.ts
+++ b/src/utils/xml.utils.ts
@@ -865,8 +865,9 @@ export function generarXMLRetencion(
 
     const pagosNode = docSustentoNode.ele('pagos');
     for (const pg of ds.pagos) {
-      // El Anexo 10 usa la etiqueta <formapago> (minúscula) para el ATS 2.0.0
-      pagosNode.ele('pago').ele('formapago').txt(pg.pago.formaPago).up().ele('total').txt(pg.pago.total).up().up();
+      // El ejemplo del Anexo 10 muestra <formapago> en minúscula, pero es un error de la
+      // ficha técnica: el XSD del SRI exige <formaPago> (error 35 si se envía en minúscula)
+      pagosNode.ele('pago').ele('formaPago').txt(pg.pago.formaPago).up().ele('total').txt(pg.pago.total).up().up();
     }
   }
 

--- a/src/utils/xml.utils.ts
+++ b/src/utils/xml.utils.ts
@@ -6,6 +6,7 @@ import { InvoiceRequest } from '../interfaces/invoice.interface';
 import { CreditNoteRequest } from '../interfaces/credit-note.interface';
 import { DebitNoteRequest } from '../interfaces/debit-note.interface';
 import { DeliveryNoteRequest } from '../interfaces/delivery-note.interface';
+import { WithholdingRequest } from '../interfaces/withholding.interface';
 
 /**
  * IVA configuration (tabla 17 de la Ficha Técnica del SRI).
@@ -680,4 +681,190 @@ export function generarXMLGuiaRemision(
   }
 
   return doc.end({ prettyPrint: true });
+}
+
+/**
+ * Genera un documento XML para un comprobante de retención electrónico según el
+ * formato ATS v2.0.0 (Anexo 10 de la Ficha Técnica del SRI, codDoc 07).
+ * Los bloques condicionales de reembolsos, dividendos y compra de cajas de
+ * banano no están incluidos en esta versión inicial.
+ * @param retencion Datos del comprobante de retención
+ * @param empresa Empresa emisora
+ * @param claveAcceso Clave de acceso generada
+ * @param secuencial Número secuencial del comprobante
+ * @returns XML del comprobante de retención como string
+ */
+export function generarXMLRetencion(
+  retencion: WithholdingRequest,
+  empresa: IIssuingCompany,
+  claveAcceso: string,
+  secuencial: string,
+): string {
+  const info = retencion.infoCompRetencion;
+
+  const infoNode = create({ version: '1.0', encoding: 'UTF-8' })
+    .ele('comprobanteRetencion', {
+      id: 'comprobante',
+      version: '2.0.0',
+    })
+    .ele('infoTributaria')
+    .ele('ambiente')
+    .txt(String(empresa.tipo_ambiente))
+    .up()
+    .ele('tipoEmision')
+    .txt(String(empresa.tipo_emision))
+    .up()
+    .ele('razonSocial')
+    .txt(empresa.razon_social)
+    .up()
+    .ele('nombreComercial')
+    .txt(empresa.nombre_comercial)
+    .up()
+    .ele('ruc')
+    .txt(empresa.ruc)
+    .up()
+    .ele('claveAcceso')
+    .txt(claveAcceso)
+    .up()
+    .ele('codDoc')
+    .txt('07')
+    .up() // comprobante de retención
+    .ele('estab')
+    .txt(empresa.codigo_establecimiento)
+    .up()
+    .ele('ptoEmi')
+    .txt(empresa.punto_emision)
+    .up()
+    .ele('secuencial')
+    .txt(secuencial)
+    .up()
+    .ele('dirMatriz')
+    .txt(empresa.direccion_matriz || empresa.direccion || 'Dirección no especificada')
+    .up()
+    .up()
+    .ele('infoCompRetencion')
+    .ele('fechaEmision')
+    .txt(info.fechaEmision)
+    .up()
+    .ele('dirEstablecimiento')
+    .txt(empresa.direccion_establecimiento || empresa.direccion || 'Dirección no especificada')
+    .up()
+    .ele('obligadoContabilidad')
+    .txt(empresa.obligado_contabilidad ? 'SI' : 'NO')
+    .up()
+    .ele('tipoIdentificacionSujetoRetenido')
+    .txt(info.tipoIdentificacionSujetoRetenido)
+    .up();
+
+  if (info.tipoSujetoRetenido) {
+    infoNode.ele('tipoSujetoRetenido').txt(info.tipoSujetoRetenido).up();
+  }
+  if (info.parteRel) {
+    infoNode.ele('parteRel').txt(info.parteRel).up();
+  }
+
+  const docsSustentoNode = infoNode
+    .ele('razonSocialSujetoRetenido')
+    .txt(info.razonSocialSujetoRetenido)
+    .up()
+    .ele('identificacionSujetoRetenido')
+    .txt(info.identificacionSujetoRetenido)
+    .up()
+    .ele('periodoFiscal')
+    .txt(info.periodoFiscal)
+    .up()
+    .up() // salir de <infoCompRetencion>
+    .ele('docsSustento');
+
+  // Cursor tracking: xmlbuilder2 returns a new node reference on each call,
+  // so nested loops must build from an explicitly captured parent node
+  for (const item of retencion.docsSustento) {
+    const ds = item.docSustento;
+    const docSustentoNode = docsSustentoNode
+      .ele('docSustento')
+      .ele('codSustento')
+      .txt(ds.codSustento)
+      .up()
+      .ele('codDocSustento')
+      .txt(ds.codDocSustento)
+      .up();
+
+    if (ds.numDocSustento) {
+      docSustentoNode.ele('numDocSustento').txt(ds.numDocSustento).up();
+    }
+
+    docSustentoNode.ele('fechaEmisionDocSustento').txt(ds.fechaEmisionDocSustento).up();
+
+    if (ds.fechaRegistroContable) {
+      docSustentoNode.ele('fechaRegistroContable').txt(ds.fechaRegistroContable).up();
+    }
+    if (ds.numAutDocSustento) {
+      docSustentoNode.ele('numAutDocSustento').txt(ds.numAutDocSustento).up();
+    }
+
+    docSustentoNode
+      .ele('pagoLocExt')
+      .txt(ds.pagoLocExt)
+      .up()
+      .ele('totalSinImpuestos')
+      .txt(ds.totalSinImpuestos)
+      .up()
+      .ele('importeTotal')
+      .txt(ds.importeTotal)
+      .up();
+
+    const impuestosNode = docSustentoNode.ele('impuestosDocSustento');
+    for (const imp of ds.impuestosDocSustento) {
+      const impuesto = imp.impuestoDocSustento;
+      impuestosNode
+        .ele('impuestoDocSustento')
+        .ele('codImpuestoDocSustento')
+        .txt(impuesto.codImpuestoDocSustento)
+        .up()
+        .ele('codigoPorcentaje')
+        .txt(impuesto.codigoPorcentaje)
+        .up()
+        .ele('baseImponible')
+        .txt(impuesto.baseImponible)
+        .up()
+        .ele('tarifa')
+        .txt(impuesto.tarifa)
+        .up()
+        .ele('valorImpuesto')
+        .txt(impuesto.valorImpuesto)
+        .up()
+        .up();
+    }
+
+    const retencionesNode = docSustentoNode.ele('retenciones');
+    for (const ret of ds.retenciones) {
+      const r = ret.retencion;
+      retencionesNode
+        .ele('retencion')
+        .ele('codigo')
+        .txt(r.codigo)
+        .up()
+        .ele('codigoRetencion')
+        .txt(r.codigoRetencion)
+        .up()
+        .ele('baseImponible')
+        .txt(r.baseImponible)
+        .up()
+        .ele('porcentajeRetener')
+        .txt(r.porcentajeRetener)
+        .up()
+        .ele('valorRetenido')
+        .txt(r.valorRetenido)
+        .up()
+        .up();
+    }
+
+    const pagosNode = docSustentoNode.ele('pagos');
+    for (const pg of ds.pagos) {
+      // El Anexo 10 usa la etiqueta <formapago> (minúscula) para el ATS 2.0.0
+      pagosNode.ele('pago').ele('formapago').txt(pg.pago.formaPago).up().ele('total').txt(pg.pago.total).up().up();
+    }
+  }
+
+  return docsSustentoNode.end({ prettyPrint: true });
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "exclude": ["__tests__", "scripts", "node_modules", "dist"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,9 @@
     "target": "es2019",
     "module": "commonjs",
     "outDir": "dist",
-    "rootDir": "src",
     "strict": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "types": ["jest", "node"]
   },
-  "exclude": ["__tests__", "scripts", "node_modules", "dist"]
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Descripción

Implementa la emisión completa de **Comprobantes de Retención electrónicos** en su versión **ATS 2.0.0** (codDoc `07`, Anexo 10 de la Ficha Técnica v2.32 del SRI). Con este PR queda **completa la serie de comprobantes electrónicos del SRI**: factura (existente), nota de crédito (#21), nota de débito (#23), guía de remisión (#25) y retención.

Resuelve #26.

> ⚠️ **Depende de #21, #23 y #25** — está apilado sobre `feature/guia-de-remision`. El commit propio de este PR es solo `feat(withholding)`. Una vez mergeados los anteriores, lo rebaso sobre main.

### Contenido

- **Modelos** `Withholding` y `WithholdingPDF` con los datos del sujeto retenido, `periodoFiscal` (mm/aaaa) y los documentos de sustento embebidos.
- **Generador XML** `generarXMLRetencion` según el Anexo 10: `<infoCompRetencion>` (con `tipoSujetoRetenido` y `parteRel` opcionales) y `<docsSustento>` — cada `<docSustento>` con códigos del **Catálogo ATS** (`codSustento`, `codDocSustento`), totales, `<impuestosDocSustento>`, las `<retenciones>` (código tabla 19, `codigoRetencion` tablas 20/21, `baseImponible`, `porcentajeRetener`, `valorRetenido`) y `<pagos>` (con la etiqueta `formapago` tal como la define el Anexo 10).
- **Alcance**: estructura core del ATS 2.0.0. Los bloques condicionales de reembolsos (`codDocSustento` 41), dividendos y compra de cajas de banano quedan documentados como extensión futura.
- **`WithholdingService`** con el flujo automático completo: clave de acceso (tipo `07`) → firma XAdES-BES (`signWithholdingCertificateXml`) → recepción → consulta de autorización con reintentos → **RIDE PDF** con el formato impreso de la versión 1.0.0 (como indica el Anexo 10), incluyendo la tabla de retenciones y el total retenido.
- **Endpoints** `POST /api/v1/withholding/complete`, CRUD y `GET /:id/pdf`, con documentación **Swagger/OpenAPI** completa (schemas de docsSustento, impuestos, retenciones y pagos).
- **Tests**: 20 nuevos (XML con orden de bloques verificado, campos opcionales, múltiples retenciones por documento, clave de acceso tipo 07, rutas con Supertest). Suite completa: **136 tests** en verde, `npm run validate` pasa.

### Cómo probar

1. `POST /api/v1/withholding/complete` con el body de ejemplo del Swagger (`/docs`), p. ej. retención de renta 312 (1.75%) + IVA 70% sobre una factura de compra.
2. Verificar en logs: `RECIBIDA` → `AUTORIZADO`, y el PDF en `GET /api/v1/withholding/:id/pdf`.

### Serie completa 🎉

| Doc | codDoc | PR |
|---|---|---|
| Nota de Crédito | 04 | #21 |
| Nota de Débito | 05 | #23 |
| Guía de Remisión | 06 | #25 |
| Comprobante de Retención ATS 2.0.0 | 07 | este PR |
